### PR TITLE
Intercept `rescanblockchain`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 /target
 **/*.rs.bk
+/bf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "anyhow"
-version = "1.0.34"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arc-swap"
@@ -61,7 +61,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 dependencies = [
  "backtrace-sys",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rustc-demangle",
 ]
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "btc-rpc-proxy"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -154,7 +154,7 @@ dependencies = [
  "configure_me_codegen",
  "derive_more",
  "enum_future",
- "futures 0.3.8",
+ "futures 0.3.12",
  "hex",
  "http",
  "hyper",
@@ -180,9 +180,9 @@ checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cache-padded"
@@ -198,7 +198,7 @@ checksum = "513d17226888c7b8283ac02a1c1b0d8a9d4cbf6db65dfadb79f598f5d7966fe9"
 dependencies = [
  "serde",
  "serde_derive",
- "toml 0.5.7",
+ "toml",
 ]
 
 [[package]]
@@ -212,6 +212,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -245,28 +251,28 @@ dependencies = [
 
 [[package]]
 name = "configure_me"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177561486192921b103fef5c54d25ded8bb6ba86e2ef4d12e0aa5aba3233a9fb"
+checksum = "d03c1fbdead926855bdafee8ddf16cd42efb3c75d8cde8c87f8937b99510b39d"
 dependencies = [
  "parse_arg",
  "serde",
  "serde_derive",
- "toml 0.4.10",
+ "toml",
 ]
 
 [[package]]
 name = "configure_me_codegen"
-version = "0.3.14"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a76c3f66dc3e41f12807d6964efcd66eb38ab602ea11eb776005eb3deb875c"
+checksum = "97f64541226ea2aaaad89ce86ec9453b1e913a54d71eb987ab9d8ed52dacce2f"
 dependencies = [
  "cargo_toml",
  "fmt2io",
  "man",
  "serde",
  "serde_derive",
- "toml 0.4.10",
+ "toml",
  "unicode-segmentation",
  "void",
 ]
@@ -279,12 +285,12 @@ checksum = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -293,18 +299,18 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -325,7 +331,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -335,7 +341,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_users",
  "winapi 0.3.8",
@@ -403,22 +409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "futures"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,9 +416,9 @@ checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -441,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -451,15 +441,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -468,15 +458,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -486,24 +476,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -512,7 +502,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -521,20 +511,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
  "bytes",
  "fnv",
@@ -547,6 +537,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -572,9 +563,9 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
  "bytes",
  "fnv",
@@ -583,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
  "bytes",
  "http",
@@ -605,9 +596,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -619,7 +610,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 1.0.1",
  "socket2",
  "tokio",
  "tower-service",
@@ -629,28 +620,28 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
+name = "instant"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "libc",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
 dependencies = [
  "either",
 ]
@@ -660,16 +651,6 @@ name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
 
 [[package]]
 name = "lazy_static"
@@ -694,12 +675,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -712,12 +702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,76 +709,24 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
- "cfg-if",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log",
- "mio",
- "miow 0.3.5",
+ "miow",
+ "ntapi",
  "winapi 0.3.8",
 ]
 
 [[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio",
-]
-
-[[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-dependencies = [
- "cfg-if",
- "libc",
  "winapi 0.3.8",
 ]
 
@@ -803,6 +735,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "ntapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
+dependencies = [
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "num-integer"
@@ -835,9 +776,34 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "parse_arg"
@@ -847,11 +813,31 @@ checksum = "14248cc8eced350e20122a291613de29e4fa129ba2731818c4cdbb44fccd3e55"
 
 [[package]]
 name = "pin-project"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+dependencies = [
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.0.1",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -870,6 +856,12 @@ name = "pin-project-lite"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -915,25 +907,24 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
- "rand_core 0.5.1",
+ "rand_core 0.6.1",
  "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -953,20 +944,20 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1040,6 +1031,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "secp256k1"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,18 +1057,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1080,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -1122,9 +1119,9 @@ checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "slog-async"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b3336ce47ce2f96673499fc07eb85e3472727b9a7a2959964b002c2ce8fbbb"
+checksum = "c60813879f820c85dbc4eabf3269befe374591289019775898d56a81a804fbdc"
 dependencies = [
  "crossbeam-channel",
  "slog",
@@ -1146,14 +1143,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.3.15"
+name = "smallvec"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.8",
 ]
 
@@ -1171,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1250,33 +1252,29 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec"
 dependencies = [
+ "autocfg",
  "bytes",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
  "libc",
  "memchr",
  "mio",
- "mio-named-pipes",
- "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite 0.2.4",
  "signal-hook-registry",
- "slab",
  "tokio-macros",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1284,26 +1282,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.3.1"
+name = "tokio-stream"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.4",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ae4751faa60b9f96dd8344d74592e5a17c0c9a220413dbc6942d14139bbfcc"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.4",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-dependencies = [
- "serde",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1327,9 +1328,8 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
- "cfg-if",
- "log",
- "pin-project-lite",
+ "cfg-if 0.1.10",
+ "pin-project-lite 0.1.10",
  "tracing-core",
 ]
 
@@ -1340,6 +1340,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.27",
+ "tracing",
 ]
 
 [[package]]
@@ -1378,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "sled",
  "slog",
  "slog-async",
  "slog-term",
@@ -278,10 +279,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -291,6 +307,20 @@ checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.1",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils 0.8.1",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
@@ -310,6 +340,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
+<<<<<<< HEAD
+=======
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+>>>>>>> block filters first try
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -401,6 +445,16 @@ name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -507,6 +561,15 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -631,6 +694,18 @@ dependencies = [
 [[package]]
 name = "instant"
 version = "0.1.9"
+<<<<<<< HEAD
+=======
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+>>>>>>> block filters first try
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
@@ -660,9 +735,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "linear-map"
@@ -685,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -708,11 +783,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
+<<<<<<< HEAD
+=======
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+>>>>>>> block filters first try
  "libc",
  "log",
  "miow",
@@ -742,6 +834,11 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
 dependencies = [
+<<<<<<< HEAD
+=======
+ "cfg-if 0.1.10",
+ "libc",
+>>>>>>> block filters first try
  "winapi 0.3.8",
 ]
 
@@ -796,6 +893,31 @@ name = "parking_lot_core"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -1112,6 +1234,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "sled"
+version = "0.34.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils 0.8.1",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot",
+]
+
+[[package]]
 name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,9 +1282,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
+<<<<<<< HEAD
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+=======
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+>>>>>>> block filters first try
 
 [[package]]
 name = "socket2"
@@ -1154,7 +1298,11 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
+<<<<<<< HEAD
  "cfg-if 1.0.0",
+=======
+ "cfg-if 0.1.10",
+>>>>>>> block filters first try
  "libc",
  "winapi 0.3.8",
 ]
@@ -1329,7 +1477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
+<<<<<<< HEAD
  "pin-project-lite 0.1.10",
+=======
+ "log",
+ "pin-project-lite",
+>>>>>>> block filters first try
  "tracing-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,20 +322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-epoch"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
-dependencies = [
- "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.1",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,31 +852,6 @@ name = "parking_lot_core"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,8 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
-<<<<<<< HEAD
-=======
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -353,7 +351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
->>>>>>> block filters first try
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -694,8 +691,6 @@ dependencies = [
 [[package]]
 name = "instant"
 version = "0.1.9"
-<<<<<<< HEAD
-=======
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
@@ -705,7 +700,6 @@ dependencies = [
 [[package]]
 name = "iovec"
 version = "0.1.4"
->>>>>>> block filters first try
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
@@ -797,14 +791,11 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
-<<<<<<< HEAD
-=======
  "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
->>>>>>> block filters first try
  "libc",
  "log",
  "miow",
@@ -834,11 +825,8 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
 dependencies = [
-<<<<<<< HEAD
-=======
  "cfg-if 0.1.10",
  "libc",
->>>>>>> block filters first try
  "winapi 0.3.8",
 ]
 
@@ -1282,15 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-<<<<<<< HEAD
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-=======
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
->>>>>>> block filters first try
 
 [[package]]
 name = "socket2"
@@ -1298,11 +1280,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
-<<<<<<< HEAD
  "cfg-if 1.0.0",
-=======
- "cfg-if 0.1.10",
->>>>>>> block filters first try
  "libc",
  "winapi 0.3.8",
 ]
@@ -1477,12 +1455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
-<<<<<<< HEAD
  "pin-project-lite 0.1.10",
-=======
- "log",
- "pin-project-lite",
->>>>>>> block filters first try
  "tracing-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 
 [[package]]
 name = "bitcoin"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aefc9be9f17185f4ebccae6575d342063f775924d57df0000edb1880c0fb7095"
+checksum = "1ec5f88a446d66e7474a3b8fa2e348320b574463fb78d799d90ba68f79f48e0e"
 dependencies = [
  "bech32",
  "bitcoin_hashes",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.9.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed2ce8078898876263683749be6f50af005cc77f93be1422f1c56fecf0b34d7"
+checksum = "0aaf87b776808e26ae93289bc7d025092b6d909c193f0cdee0b3a86e7bd3c776"
 dependencies = [
  "serde",
 ]
@@ -1041,9 +1041,9 @@ checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
 name = "secp256k1"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
+checksum = "733b114f058f260c0af7591434eef4272ae1a8ec2751766d3cb89c6df8d5e450"
 dependencies = [
  "secp256k1-sys",
  "serde",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
+checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,7 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 
 [[package]]
 name = "bitcoin"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec5f88a446d66e7474a3b8fa2e348320b574463fb78d799d90ba68f79f48e0e"
+version = "0.25.2"
 dependencies = [
  "bech32",
  "bitcoin_hashes",
@@ -329,17 +327,6 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 dependencies = [
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
-dependencies = [
- "autocfg",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -698,15 +685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,11 +769,6 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
  "miow",
@@ -825,8 +798,6 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
 dependencies = [
- "cfg-if 0.1.10",
- "libc",
  "winapi 0.3.8",
 ]
 
@@ -881,31 +852,6 @@ name = "parking_lot_core"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -1148,9 +1094,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secp256k1"
-version = "0.20.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733b114f058f260c0af7591434eef4272ae1a8ec2751766d3cb89c6df8d5e450"
+checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
 dependencies = [
  "secp256k1-sys",
  "serde",
@@ -1158,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
+checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils 0.8.1",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +866,31 @@ name = "parking_lot_core"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ linear-map = { version = "1.2.0", features = ["serde_impl"] }
 rand = "0.8.2"
 serde = { version = "1.0.120", features = ["derive"] }
 serde_json = "1.0.61"
+sled = "0.34.6"
 slog = "2.7.0"
 slog-async = "2.6.0"
 slog-term = "2.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 description = "Finer-grained permission management for bitcoind."
 edition = "2018"
 name = "btc-rpc-proxy"
-version = "0.2.3"
+version = "0.2.4"
 
 [lib]
 name = "btc_rpc_proxy"
@@ -25,33 +25,33 @@ old_rust = []
 debug_logs = ["slog/max_level_debug"]
 
 [dependencies]
-anyhow = "1.0.34"
+anyhow = "1.0.38"
 async-channel = "1.5.1"
 base32 = "0.4.0"
 base64 = "0.13.0"
 bitcoin = { version = "0.26.0", features = ["use-serde"] }
-configure_me = { version = "0.3.4" }
+configure_me = { version = "0.4.0" }
 derive_more = "0.99.11"
 enum_future = "0.1"
-futures = "0.3.8"
+futures = "0.3.12"
 hex = "0.4.2"
-http = "0.2.1"
-hyper = "0.13.9"
-itertools = "0.9.0"
+http = "0.2.3"
+hyper = { version = "0.14.2", features = ["client", "server", "http2", "tcp"] }
+itertools = "0.10.0"
 lazy_static = "1.4.0"
 linear-map = { version = "1.2.0", features = ["serde_impl"] }
-rand = "0.7.3"
-serde = { version = "1.0.117", features = ["derive"] }
-serde_json = "1.0.59"
+rand = "0.8.2"
+serde = { version = "1.0.120", features = ["derive"] }
+serde_json = "1.0.61"
 slog = "2.7.0"
-slog-async = "2.5.0"
+slog-async = "2.6.0"
 slog-term = "2.6.0"
 socks = "0.3.3"
-tokio = { version = "0.2.22", features = ["full"] }
+tokio = { version = "1.0.2", features = ["full"] }
 thiserror = "1.0.22"
 
 [build-dependencies]
-configure_me_codegen = "0.3.14"
+configure_me_codegen = "0.4.0"
 
 [package.metadata.deb]
 assets = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ enum_future = "0.1"
 futures = "0.3.12"
 hex = "0.4.2"
 http = "0.2.3"
-hyper = { version = "0.14.2", features = ["client", "server", "http2", "tcp"] }
+hyper = { version = "0.14.2", features = ["client", "server", "http2", "http1", "tcp"] }
 itertools = "0.10.0"
 lazy_static = "1.4.0"
 linear-map = { version = "1.2.0", features = ["serde_impl"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ anyhow = "1.0.38"
 async-channel = "1.5.1"
 base32 = "0.4.0"
 base64 = "0.13.0"
-bitcoin = { version = "0.26.0", features = ["use-serde"] }
+bitcoin = { path = "../rust-bitcoin", features = ["use-serde"] }
 configure_me = { version = "0.4.0" }
 derive_more = "0.99.11"
 enum_future = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ anyhow = "1.0.34"
 async-channel = "1.5.1"
 base32 = "0.4.0"
 base64 = "0.13.0"
-bitcoin = { version = "0.25.2", features = ["use-serde"] }
+bitcoin = { version = "0.26.0", features = ["use-serde"] }
 configure_me = { version = "0.3.4" }
 derive_more = "0.99.11"
 enum_future = "0.1"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -54,7 +54,7 @@ doc = "The port of the real bitcoind."
 
 [[param]]
 name = "user"
-type = "std::collections::HashMap<String, btc_rpc_proxy::users::input::User>"
+type = "std::collections::HashMap<String, crate::users::input::User>"
 merge_fn = "std::iter::Extend::extend"
 default = "Default::default()"
 argument = false

--- a/src/block_filters.rs
+++ b/src/block_filters.rs
@@ -1,15 +1,8 @@
-// #[macro_use]
-// extern crate sled;
-// use crate::client::{RpcResponse, GenericRpcMethod, RpcError};
-// use crate::client::{
-//     GenericRpcMethod, RpcError, RpcMethod, RpcRequest, RpcResponse, METHOD_NOT_ALLOWED_ERROR_CODE,
-//     METHOD_NOT_ALLOWED_ERROR_MESSAGE, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE,
-// };
 use crate::{client::{
         GenericRpcMethod, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE, RpcError, 
         RpcRequest, 
         RpcResponse
-    }, fetch_blocks::{fetch_block, fetch_filter, fetch_filter_from_peers}, rpc_methods::{
+    }, fetch_blocks::{fetch_block, fetch_filters_from_peers, fetch_cf_checkpts_from_peers, fetch_cf_headers_from_peers}, rpc_methods::{
         GetBlockCount, GetBlockHash, 
         // GetBlockHeader, GetBlockHeaderParams, GetBlockResult
     }};
@@ -17,153 +10,16 @@ use crate::{
     state::State, 
     create_state
 };
-use std::{collections::HashMap, sync::Arc};
-// use std::io::Cursor;
-// use anyhow::Error;
+use std::{collections::HashMap, sync::Arc, time::SystemTime};
 use anyhow::{anyhow, Context, Error};
-use bitcoin::{
-    Block, OutPoint, Script, 
-    // Transaction, TxMerkleNode, 
-    consensus::{Encodable, encode::deserialize, Decodable},
-    hash_types::{BlockHash, FilterHash}, 
-    hashes::hex::{FromHex, ToHex},
-    util::bip158::{
+use bitcoin::{Block, FilterHeader, OutPoint, Script, consensus::{Encodable, encode::deserialize, Decodable}, hash_types::{BlockHash, FilterHash}, hashes::hex::{FromHex, ToHex}, util::bip158::{
         BlockFilter, 
-        // Error::UtxoMissing
-    }
-};
+    }};
 
+use enum_future::futures::stream::Filter;
 use serde_json::Value;
 use sled::Tree;
 
-// fn get_block_filter_from_db(block_hash: BlockHash) -> Result<BlockFilter, Error> {
-//     println!("Block hash to_hex: {}", block_hash);
-//     // Ok(BlockFilter::new())
-// }
-
-
-/// fetches block filter from db, if matches, fetches block, and finds relevant txs, and returns them, along with merkle proofs
-// pub async fn get_relevant_txs(state: Arc<State>, block_hash: BlockHash, script: Script) -> Result<Vec<(Transaction, TxMerkleNode)>, Error> {
-// // pub async fn get_relevant_txs(state: Arc<State>, block_hash: BlockHash, script: Script) -> Result<Option<RpcResponse<GenericRpcMethod>>, RpcError> {
-//     println!("Getting relevant txs");
-//     // let res: Result<Vec<(Transaction, TxMerkleNode)> = Result(Vec<(Transaction, TxMerkleNode));
-//     let block: Block =
-//     match fetch_block(
-//         state.clone(),
-//         state.get_peers().await?,
-//         // serde_json::from_value(req.params[0].clone()).map_err(Error::from)?,
-//         block_hash,
-
-//     )
-//     .await
-//     {
-//         Ok(Some(block)) => {
-//             // Ok(Vec::new())
-//             block
-//                 .consensus_encode(&mut block_data)
-//                 .map_err(Error::from)?;
-//             let block_data = hex::encode(&block_data);
-//             Ok(Some(RpcResponse {
-//                 // id: req.id.clone(),
-//                 id: None,
-//                 result: Some(Value::String(block_data)),
-//                 error: None,
-//             }))
-//         }
-//         Ok(None) => {
-//             Ok(Vec::new())
-//         },
-        
-//         // Ok(Some(RpcResponse {
-//         //     id: None,
-//         //     result: None,
-//         //     error: Some(RpcError {
-//         //         code: MISC_ERROR_CODE,
-//         //         message: PRUNE_ERROR_MESSAGE.to_owned(),
-//         //         status: None,
-//         //     }),
-//         // })),
-//         Err(e) => Ok(Vec::new()),
-//     };
-//     Ok(Vec::new())
-// }
-
-// fn initialize_db() -> Result<HashMap<BlockHash, BlockFilter>, Error> {
-// fn initialize_filter_index() -> Result<HashMap<BlockHash, BlockFilter>, Error> {
-//     let data = r#"
-//     [
-//         ["Block Height,Block Hash,Block,[Prev Output Scripts for Block],Previous Basic Header,Basic Filter,Basic Header,Notes"],
-//         [0,"000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943","0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff001d1aa4ae180101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000",[],"0000000000000000000000000000000000000000000000000000000000000000","019dfca8","21584579b7eb08997773e5aeff3a7f932700042d0ed2a6129012b7d7ae81b750","Genesis block"],
-//         [2,"000000006c02c8ea6e4ff69651f7fcde348fb9d557a06e6957b65552002a7820","0100000006128e87be8b1b4dea47a7247d5528d2702c96826c7a648497e773b800000000e241352e3bec0a95a6217e10c3abb54adfa05abb12c126695595580fb92e222032e7494dffff001d00d235340101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0e0432e7494d010e062f503253482fffffffff0100f2052a010000002321038a7f6ef1c8ca0c588aa53fa860128077c9e6c11e6830f4d7ee4e763a56b7718fac00000000",[],"d7bdac13a59d745b1add0d2ce852f1a0442e8945fc1bf3848d3cbffd88c24fe1","0174a170","186afd11ef2b5e7e3504f2e8cbf8df28a1fd251fe53d60dff8b1467d1b386cf0",""],
-//         [3,"000000008b896e272758da5297bcd98fdc6d97c9b765ecec401e286dc1fdbe10","0100000020782a005255b657696ea057d5b98f34defcf75196f64f6eeac8026c0000000041ba5afc532aae03151b8aa87b65e1594f97504a768e010c98c0add79216247186e7494dffff001d058dc2b60101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0e0486e7494d0151062f503253482fffffffff0100f2052a01000000232103f6d9ff4c12959445ca5549c811683bf9c88e637b222dd2e0311154c4c85cf423ac00000000",[],"186afd11ef2b5e7e3504f2e8cbf8df28a1fd251fe53d60dff8b1467d1b386cf0","016cf7a0","8d63aadf5ab7257cb6d2316a57b16f517bff1c6388f124ec4c04af1212729d2a",""],
-//         [15007,"0000000038c44c703bae0f98cdd6bf30922326340a5996cc692aaae8bacf47ad","0100000002394092aa378fe35d7e9ac79c869b975c4de4374cd75eb5484b0e1e00000000eb9b8670abd44ad6c55cee18e3020fb0c6519e7004b01a16e9164867531b67afc33bc94fffff001d123f10050101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0e04c33bc94f0115062f503253482fffffffff0100f2052a01000000232103f268e9ae07e0f8cb2f6e901d87c510d650b97230c0365b021df8f467363cafb1ac00000000",[],"18b5c2b0146d2d09d24fb00ff5b52bd0742f36c9e65527abdb9de30c027a4748","013c3710","07384b01311867949e0c046607c66b7a766d338474bb67f66c8ae9dbd454b20e","Tx has non-standard OP_RETURN output followed by opcodes"],
-//         [49291,"0000000018b07dca1b28b4b5a119f6d6e71698ce1ed96f143f54179ce177a19c","02000000abfaf47274223ca2fea22797e44498240e482cb4c2f2baea088962f800000000604b5b52c32305b15d7542071d8b04e750a547500005d4010727694b6e72a776e55d0d51ffff001d211806480201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0d038bc0000102062f503253482fffffffff01a078072a01000000232102971dd6034ed0cf52450b608d196c07d6345184fcb14deb277a6b82d526a6163dac0000000001000000081cefd96060ecb1c4fbe675ad8a4f8bdc61d634c52b3a1c4116dee23749fe80ff000000009300493046022100866859c21f306538152e83f115bcfbf59ab4bb34887a88c03483a5dff9895f96022100a6dfd83caa609bf0516debc2bf65c3df91813a4842650a1858b3f61cfa8af249014730440220296d4b818bb037d0f83f9f7111665f49532dfdcbec1e6b784526e9ac4046eaa602204acf3a5cb2695e8404d80bf49ab04828bcbe6fc31d25a2844ced7a8d24afbdff01ffffffff1cefd96060ecb1c4fbe675ad8a4f8bdc61d634c52b3a1c4116dee23749fe80ff020000009400483045022100e87899175991aa008176cb553c6f2badbb5b741f328c9845fcab89f8b18cae2302200acce689896dc82933015e7230e5230d5cff8a1ffe82d334d60162ac2c5b0c9601493046022100994ad29d1e7b03e41731a4316e5f4992f0d9b6e2efc40a1ccd2c949b461175c502210099b69fdc2db00fbba214f16e286f6a49e2d8a0d5ffc6409d87796add475478d601ffffffff1e4a6d2d280ea06680d6cf8788ac90344a9c67cca9b06005bbd6d3f6945c8272010000009500493046022100a27400ba52fd842ce07398a1de102f710a10c5599545e6c95798934352c2e4df022100f6383b0b14c9f64b6718139f55b6b9494374755b86bae7d63f5d3e583b57255a01493046022100fdf543292f34e1eeb1703b264965339ec4a450ec47585009c606b3edbc5b617b022100a5fbb1c8de8aaaa582988cdb23622838e38de90bebcaab3928d949aa502a65d401ffffffff1e4a6d2d280ea06680d6cf8788ac90344a9c67cca9b06005bbd6d3f6945c8272020000009400493046022100ac626ac3051f875145b4fe4cfe089ea895aac73f65ab837b1ac30f5d875874fa022100bc03e79fa4b7eb707fb735b95ff6613ca33adeaf3a0607cdcead4cfd3b51729801483045022100b720b04a5c5e2f61b7df0fcf334ab6fea167b7aaede5695d3f7c6973496adbf1022043328c4cc1cdc3e5db7bb895ccc37133e960b2fd3ece98350f774596badb387201ffffffff23a8733e349c97d6cd90f520fdd084ba15ce0a395aad03cd51370602bb9e5db3010000004a00483045022100e8556b72c5e9c0da7371913a45861a61c5df434dfd962de7b23848e1a28c86ca02205d41ceda00136267281be0974be132ac4cda1459fe2090ce455619d8b91045e901ffffffff6856d609b881e875a5ee141c235e2a82f6b039f2b9babe82333677a5570285a6000000006a473044022040a1c631554b8b210fbdf2a73f191b2851afb51d5171fb53502a3a040a38d2c0022040d11cf6e7b41fe1b66c3d08f6ada1aee07a047cb77f242b8ecc63812c832c9a012102bcfad931b502761e452962a5976c79158a0f6d307ad31b739611dac6a297c256ffffffff6856d609b881e875a5ee141c235e2a82f6b039f2b9babe82333677a5570285a601000000930048304502205b109df098f7e932fbf71a45869c3f80323974a826ee2770789eae178a21bfc8022100c0e75615e53ee4b6e32b9bb5faa36ac539e9c05fa2ae6b6de5d09c08455c8b9601483045022009fb7d27375c47bea23b24818634df6a54ecf72d52e0c1268fb2a2c84f1885de022100e0ed4f15d62e7f537da0d0f1863498f9c7c0c0a4e00e4679588c8d1a9eb20bb801ffffffffa563c3722b7b39481836d5edfc1461f97335d5d1e9a23ade13680d0e2c1c371f030000006c493046022100ecc38ae2b1565643dc3c0dad5e961a5f0ea09cab28d024f92fa05c922924157e022100ebc166edf6fbe4004c72bfe8cf40130263f98ddff728c8e67b113dbd621906a601210211a4ed241174708c07206601b44a4c1c29e5ad8b1f731c50ca7e1d4b2a06dc1fffffffff02d0223a00000000001976a91445db0b779c0b9fa207f12a8218c94fc77aff504588ac80f0fa02000000000000000000",["5221033423007d8f263819a2e42becaaf5b06f34cb09919e06304349d950668209eaed21021d69e2b68c3960903b702af7829fadcd80bd89b158150c85c4a75b2c8cb9c39452ae","52210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179821021d69e2b68c3960903b702af7829fadcd80bd89b158150c85c4a75b2c8cb9c39452ae","522102a7ae1e0971fc1689bd66d2a7296da3a1662fd21a53c9e38979e0f090a375c12d21022adb62335f41eb4e27056ac37d462cda5ad783fa8e0e526ed79c752475db285d52ae","52210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179821022adb62335f41eb4e27056ac37d462cda5ad783fa8e0e526ed79c752475db285d52ae","512103b9d1d0e2b4355ec3cdef7c11a5c0beff9e8b8d8372ab4b4e0aaf30e80173001951ae","76a9149144761ebaccd5b4bbdc2a35453585b5637b2f8588ac","522103f1848b40621c5d48471d9784c8174ca060555891ace6d2b03c58eece946b1a9121020ee5d32b54d429c152fdc7b1db84f2074b0564d35400d89d11870f9273ec140c52ae","76a914f4fa1cc7de742d135ea82c17adf0bb9cf5f4fb8388ac"],"ed47705334f4643892ca46396eb3f4196a5e30880589e4009ef38eae895d4a13","0afbc2920af1b027f31f87b592276eb4c32094bb4d3697021b4c6380","b6d98692cec5145f67585f3434ec3c2b3030182e1cb3ec58b855c5c164dfaaa3","Tx pays to empty output script"],
-//         [180480,"00000000fd3ceb2404ff07a785c7fdcc76619edc8ed61bd25134eaa22084366a","020000006058aa080a655aa991a444bd7d1f2defd9a3bbe68aabb69030cf3b4e00000000d2e826bfd7ef0beaa891a7eedbc92cd6a544a6cb61c7bdaa436762eb2123ef9790f5f552ffff001d0002c90f0501000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0e0300c102024608062f503253482fffffffff01c0c6072a01000000232102e769e60137a4df6b0df8ebd387cca44c4c57ae74cc0114a8e8317c8f3bfd85e9ac00000000010000000381a0802911a01ffb025c4dea0bc77963e8c1bb46313b71164c53f72f37fe5248010000000151ffffffffc904b267833d215e2128bd9575242232ac2bc311550c7fc1f0ef6f264b40d14c010000000151ffffffffdf0915666649dba81886519c531649b7b02180b4af67d6885e871299e9d5f775000000000151ffffffff0180817dcb00000000232103bb52138972c48a132fc1f637858c5189607dd0f7fe40c4f20f6ad65f2d389ba4ac0000000001000000018da38b434fba82d66052af74fc5e4e94301b114d9bc03f819dc876398404c8b4010000006c493046022100fe738b7580dc5fb5168e51fc61b5aed211125eb71068031009a22d9bbad752c5022100be5086baa384d40bcab0fa586e4f728397388d86e18b66cc417dc4f7fa4f9878012103f233299455134caa2687bdf15cb0becdfb03bd0ff2ff38e65ec6b7834295c34fffffffff022ebc1400000000001976a9147779b7fba1c1e06b717069b80ca170e8b04458a488ac9879c40f000000001976a9142a0307cd925dbb66b534c4db33003dd18c57015788ac0000000001000000026139a62e3422a602de36c873a225c1d3ca5aeee598539ceecb9f0dc8d1ad0f83010000006b483045022100ad9f32b4a0a2ddc19b5a74eba78123e57616f1b3cfd72ce68c03ea35a3dda1f002200dbd22aa6da17213df5e70dfc3b2611d40f70c98ed9626aa5e2cde9d97461f0a012103ddb295d2f1e8319187738fb4b230fdd9aa29d0e01647f69f6d770b9ab24eea90ffffffff983c82c87cf020040d671956525014d5c2b28c6d948c85e1a522362c0059eeae010000006b4830450221009ca544274c786d30a5d5d25e17759201ea16d3aedddf0b9e9721246f7ef6b32e02202cfa5564b6e87dfd9fd98957820e4d4e6238baeb0f65fe305d91506bb13f5f4f012103c99113deac0d5d044e3ac0346abc02501542af8c8d3759f1382c72ff84e704f7ffffffff02c0c62d00000000001976a914ae19d27efe12f5a886dc79af37ad6805db6f922d88ac70ce2000000000001976a9143b8d051d37a07ea1042067e93efe63dbf73920b988ac000000000100000002be566e8cd9933f0c75c4a82c027f7d0c544d5c101d0607ef6ae5d07b98e7f1dc000000006b483045022036a8cdfd5ea7ebc06c2bfb6e4f942bbf9a1caeded41680d11a3a9f5d8284abad022100cacb92a5be3f39e8bc14db1710910ef7b395fa1e18f45d41c28d914fcdde33be012102bf59abf110b5131fae0a3ce1ec379329b4c896a6ae5d443edb68529cc2bc7816ffffffff96cf67645b76ceb23fe922874847456a15feee1655082ff32d25a6bf2c0dfc90000000006a47304402203471ca2001784a5ac0abab583581f2613523da47ec5f53df833c117b5abd81500220618a2847723d57324f2984678db556dbca1a72230fc7e39df04c2239942ba942012102925c9794fd7bb9f8b29e207d5fc491b1150135a21f505041858889fa4edf436fffffffff026c840f00000000001976a914797fb8777d7991d8284d88bfd421ce520f0f843188ac00ca9a3b000000001976a9146d10f3f592699265d10b106eda37c3ce793f7a8588ac00000000",["","","","76a9142903b138c24be9e070b3e73ec495d77a204615e788ac","76a91433a1941fd9a37b9821d376f5a51bd4b52fa50e2888ac","76a914e4374e8155d0865742ca12b8d4d14d41b57d682f88ac","76a914001fa7459a6cfc64bdc178ba7e7a21603bb2568f88ac","76a914f6039952bc2b307aeec5371bfb96b66078ec17f688ac"],"d34ef98386f413769502808d4bac5f20f8dfd5bffc9eedafaa71de0eb1f01489","0db414c859a07e8205876354a210a75042d0463404913d61a8e068e58a3ae2aa080026","c582d51c0ca365e3fcf36c51cb646d7f83a67e867cb4743fd2128e3e022b700c","Tx spends from empty output script"],
-//         [926485,"000000000000015d6077a411a8f5cc95caf775ccf11c54e27df75ce58d187313","0000002060bbab0edbf3ef8a49608ee326f8fd75c473b7e3982095e2d100000000000000c30134f8c9b6d2470488d7a67a888f6fa12f8692e0c3411fbfb92f0f68f67eedae03ca57ef13021acc22dc4105010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff2f0315230e0004ae03ca57043e3d1e1d0c8796bf579aef0c0000000000122f4e696e6a61506f6f6c2f5345475749542fffffffff038427a112000000001976a914876fbb82ec05caa6af7a3b5e5a983aae6c6cc6d688ac0000000000000000266a24aa21a9ed5c748e121c0fe146d973a4ac26fa4a68b0549d46ee22d25f50a5e46fe1b377ee00000000000000002952534b424c4f434b3acd16772ad61a3c5f00287480b720f6035d5e54c9efc71be94bb5e3727f10909001200000000000000000000000000000000000000000000000000000000000000000000000000100000000010145310e878941a1b2bc2d33797ee4d89d95eaaf2e13488063a2aa9a74490f510a0100000023220020b6744de4f6ec63cc92f7c220cdefeeb1b1bed2b66c8e5706d80ec247d37e65a1ffffffff01002d3101000000001976a9143ebc40e411ed3c76f86711507ab952300890397288ac0400473044022001dd489a5d4e2fbd8a3ade27177f6b49296ba7695c40dbbe650ea83f106415fd02200b23a0602d8ff1bdf79dee118205fc7e9b40672bf31563e5741feb53fb86388501483045022100f88f040e90cc5dc6c6189d04718376ac19ed996bf9e4a3c29c3718d90ffd27180220761711f16c9e3a44f71aab55cbc0634907a1fa8bb635d971a9a01d368727bea10169522103b3623117e988b76aaabe3d63f56a4fc88b228a71e64c4cc551d1204822fe85cb2103dd823066e096f72ed617a41d3ca56717db335b1ea47a1b4c5c9dbdd0963acba621033d7c89bd9da29fa8d44db7906a9778b53121f72191184a9fee785c39180e4be153ae00000000010000000120925534261de4dcebb1ed5ab1b62bfe7a3ef968fb111dc2c910adfebc6e3bdf010000006b483045022100f50198f5ae66211a4f485190abe4dc7accdabe3bc214ebc9ea7069b97097d46e0220316a70a03014887086e335fc1b48358d46cd6bdc9af3b57c109c94af76fc915101210316cff587a01a2736d5e12e53551b18d73780b83c3bfb4fcf209c869b11b6415effffffff0220a10700000000001976a91450333046115eaa0ac9e0216565f945070e44573988ac2e7cd01a000000001976a914c01a7ca16b47be50cbdbc60724f701d52d75156688ac00000000010000000203a25f58630d7a1ea52550365fd2156683f56daf6ca73a4b4bbd097e66516322010000006a47304402204efc3d70e4ca3049c2a425025edf22d5ca355f9ec899dbfbbeeb2268533a0f2b02204780d3739653035af4814ea52e1396d021953f948c29754edd0ee537364603dc012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff03a25f58630d7a1ea52550365fd2156683f56daf6ca73a4b4bbd097e66516322000000006a47304402202d96defdc5b4af71d6ba28c9a6042c2d5ee7bc6de565d4db84ef517445626e03022022da80320e9e489c8f41b74833dfb6a54a4eb5087cdb46eb663eef0b25caa526012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff0200e1f5050000000017a914b7e6f7ff8658b2d1fb107e3d7be7af4742e6b1b3876f88fc00000000001976a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac0000000001000000043ffd60d3818431c495b89be84afac205d5d1ed663009291c560758bbd0a66df5010000006b483045022100f344607de9df42049688dcae8ff1db34c0c7cd25ec05516e30d2bc8f12ac9b2f022060b648f6a21745ea6d9782e17bcc4277b5808326488a1f40d41e125879723d3a012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffffa5379401cce30f84731ef1ba65ce27edf2cc7ce57704507ebe8714aa16a96b92010000006a473044022020c37a63bf4d7f564c2192528709b6a38ab8271bd96898c6c2e335e5208661580220435c6f1ad4d9305d2c0a818b2feb5e45d443f2f162c0f61953a14d097fd07064012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff70e731e193235ff12c3184510895731a099112ffca4b00246c60003c40f843ce000000006a473044022053760f74c29a879e30a17b5f03a5bb057a5751a39f86fa6ecdedc36a1b7db04c022041d41c9b95f00d2d10a0373322a9025dba66c942196bc9d8adeb0e12d3024728012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff66b7a71b3e50379c8e85fc18fe3f1a408fc985f257036c34702ba205cef09f6f000000006a4730440220499bf9e2db3db6e930228d0661395f65431acae466634d098612fd80b08459ee022040e069fc9e3c60009f521cef54c38aadbd1251aee37940e6018aadb10f194d6a012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff0200e1f5050000000017a9148fc37ad460fdfbd2b44fe446f6e3071a4f64faa6878f447f0b000000001976a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac00000000",["a914feb8a29635c56d9cd913122f90678756bf23887687","76a914c01a7ca16b47be50cbdbc60724f701d52d75156688ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac"],"8f13b9a9c85611635b47906c3053ac53cfcec7211455d4cb0d63dc9acc13d472","09027acea61b6cc3fb33f5d52f7d088a6b2f75d234e89ca800","546c574a0472144bcaf9b6aeabf26372ad87c7af7d1ee0dbfae5e099abeae49c","Duplicate pushdata 913bcc2be49cb534c20474c4dee1e9c4c317e7eb"],
-//         [987876,"0000000000000c00901f2049055e2a437c819d79a3d54fd63e6af796cd7b8a79","000000202694f74969fdb542090e95a56bc8aa2d646e27033850e32f1c5f000000000000f7e53676b3f12d5beb524ed617f2d25f5a93b5f4f52c1ba2678260d72712f8dd0a6dfe5740257e1a4b1768960101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1603e4120ff9c30a1c216900002f424d4920546573742fffffff0001205fa012000000001e76a914c486de584a735ec2f22da7cd9681614681f92173d83d0aa68688ac00000000",[],"fe4d230dbb0f4fec9bed23a5283e08baf996e3f32b93f52c7de1f641ddfd04ad","010c0b40","0965a544743bbfa36f254446e75630c09404b3d164a261892372977538928ed5","Coinbase tx has unparseable output script"],
-//         [1263442,"000000006f27ddfe1dd680044a34548f41bed47eba9e6f0b310da21423bc5f33","000000201c8d1a529c39a396db2db234d5ec152fa651a2872966daccbde028b400000000083f14492679151dbfaa1a825ef4c18518e780c1f91044180280a7d33f4a98ff5f45765aaddc001d38333b9a02010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff230352471300fe5f45765afe94690a000963676d696e6572343208000000000000000000ffffffff024423a804000000001976a914f2c25ac3d59f3d674b1d1d0a25c27339aaac0ba688ac0000000000000000266a24aa21a9edcb26cb3052426b9ebb4d19c819ef87c19677bbf3a7c46ef0855bd1b2abe83491012000000000000000000000000000000000000000000000000000000000000000000000000002000000000101d20978463906ba4ff5e7192494b88dd5eb0de85d900ab253af909106faa22cc5010000000004000000014777ff000000000016001446c29eabe8208a33aa1023c741fa79aa92e881ff0347304402207d7ca96134f2bcfdd6b536536fdd39ad17793632016936f777ebb32c22943fda02206014d2fb8a6aa58279797f861042ba604ebd2f8f61e5bddbd9d3be5a245047b201004b632103eeaeba7ce5dc2470221e9517fb498e8d6bd4e73b85b8be655196972eb9ccd5566754b2752103a40b74d43df244799d041f32ce1ad515a6cd99501701540e38750d883ae21d3a68ac00000000",["002027a5000c7917f785d8fc6e5a55adfca8717ecb973ebb7743849ff956d896a7ed"],"31d66d516a9eda7de865df29f6ef6cb8e4bf9309e5dac899968a9a62a5df61e3","0385acb4f0fe889ef0","4e6d564c2a2452065c205dd7eb2791124e0c4e0dbb064c410c24968572589dec","Includes witness data"],
-//         [1414221,"0000000000000027b2b3b3381f114f674f481544ff2be37ae3788d7e078383b1","000000204ea88307a7959d8207968f152bedca5a93aefab253f1fb2cfb032a400000000070cebb14ec6dbc27a9dfd066d9849a4d3bac5f674665f73a5fe1de01a022a0c851fda85bf05f4c19a779d1450102000000010000000000000000000000000000000000000000000000000000000000000000ffffffff18034d94154d696e6572476174653030310d000000f238f401ffffffff01c817a804000000000000000000",[],"5e5e12d90693c8e936f01847859404c67482439681928353ca1296982042864e","00","021e8882ef5a0ed932edeebbecfeda1d7ce528ec7b3daa27641acf1189d7b5dc","Empty data"]
-//     ]
-//     "#;
-
-//     let testdata = serde_json::from_str::<Value>(data).unwrap().as_array().unwrap().clone();
-//     let mut filters = HashMap::new();
-//     for t in testdata.iter().skip(1) {
-//         let block_hash = BlockHash::from_hex(&t.get(1).unwrap().as_str().unwrap()).unwrap();
-//         // println!("block hash: {:?}", block_hash);
-//         let block: Block = deserialize(&Vec::from_hex(&t.get(2).unwrap().as_str().unwrap()).unwrap()).unwrap();
-//         assert_eq!(block.block_hash(), block_hash);
-//         let scripts = t.get(3).unwrap().as_array().unwrap();
-//         let previous_filter_id = FilterHash::from_hex(&t.get(4).unwrap().as_str().unwrap()).unwrap();
-//         let filter_content = Vec::from_hex(&t.get(5).unwrap().as_str().unwrap()).unwrap();
-//         // println!("filter content: {:?}", filter_content);
-//         filters.insert(block_hash, BlockFilter::new(&filter_content));
-//         // filters.insert(block_hash, filter_content);
-//         let filter_id = FilterHash::from_hex(&t.get(6).unwrap().as_str().unwrap()).unwrap();
-//         // println!("filter id: {:?}", filter_id);
-
-//         let mut txmap = HashMap::new();
-//         let mut si = scripts.iter();
-//         for tx in block.txdata.iter().skip(1) {
-//             for input in tx.input.iter() {
-//                 txmap.insert(input.previous_output.clone(), Script::from(Vec::from_hex(si.next().unwrap().as_str().unwrap()).unwrap()));
-//             }
-//         }
-//         // println!("{:?}", get_block_filter(block_hash).unwrap());
-//     }
-//     Ok(filters)
-// }
-
-// fn get_block_filter(block_hash: BlockHash) -> Result<BlockFilter, Error> {
-//     println!("Getting block filter for hash: {}", block_hash);
-    // let filter = BlockFilter::new_script_filter(&block,
-    //                             |o| if let Some(s) = txmap.get(o) {
-    //                                 Ok(s.clone())
-    //                             } else {
-    //                                 Err(bitcoin::util::bip158::Error::UtxoMissing(o.clone()))
-    //                             }).unwrap();
-//     Ok(filter)
-// }
-
-/// fetches a block and stores its filter
-// pub async fn index_block_filter(state: Arc<State>, hash: BlockHash) -> Result<BlockFilter, bitcoin::Error> {
-pub async fn index_block_filter(state: Arc<State>, hash: BlockHash) -> Result<Block, bitcoin::Error> {
-    println!("State = {:?}, BlockHash = {:?}", state, hash);
-    let result =
-            fetch_block(state.clone(), state.clone().get_peers().await.unwrap(), hash);
-    let block = result.await.unwrap().unwrap();
-    // println!("block = {:?}", block);
-    // let filter = BlockFilter::new_script_filter(&block,
-    //     |o| if let Some(s) = Ok::<_, std::convert::Infallible>(o.script_pubkey.clone()) {
-    //         Ok(s.clone())
-    //     } else {
-    //         Err(UtxoMissing(o.clone()))
-    //     }).unwrap();
-    // Ok(filter)
-    Ok(block)
-}
-
-// fn get_script_for_coin (coin: &OutPoint) -> Result<Script, BlockFilterError> {
 fn get_script_for_coin (utxo_tree: Tree, coin: &OutPoint) -> Result<Script, bitcoin::util::bip158::Error> {
     // let db: sled::Db = sled::open("bf").unwrap();
     // let utxo_tree = db.open_tree("utxo").unwrap();
@@ -277,49 +133,98 @@ pub async fn build_filter_index_from_peers(state: Arc<State>) -> Result<(), Erro
         ;
     let db: sled::Db = sled::open("bf").unwrap();
     let bf_tree = db.open_tree("bf").unwrap();
+    let fh_tree = db.open_tree("fh").unwrap();
     // for i in 0..=count {
     let count = result.unwrap(); 
     println!("count={}", count);
-    // for i in 0..=count {
-    for i in 0..=1 {
-    // for i in 0..=count {
-        if i % 1000 == 0 {
-            println!("requesting block hash for height {:?}", i);
-        }
-        // }
 
-        // loop {
-        // let filter = fetch_filter_by_height(
-        //     state.clone(), i
-        // )
-        // .await?;
-        // println!("getting block hash");
-        let block_hash = get_block_hash(state.clone(), i).await?;
-        let filter = match fetch_filter_from_peers(
-            state.clone(), 
-            state.clone().get_peers().await.unwrap(), 
-            i as u32,
-            block_hash
-        )
-        .await 
-        {
-            Some(filter) => {
-                if i == 134335 {
-                    println!("Some filter on fetch_filter_from_peers for hash = {}", block_hash);
+    // fetch checkpoints
+    let checkpts = 
+        fetch_cf_checkpts_from_peers(
+            state.clone(),
+            state.clone().get_peers().await.unwrap(),
+            get_block_hash(state.clone(), count).await.unwrap(),
+        ).await.unwrap();
+        
+    // fetch and verify filter header chain against checkpoints
+    let mut all_headers = Vec::<FilterHeader>::new();
+    for (i, ckpt_header) in checkpts.iter().enumerate() {
+        let ckpt_height =  (i +1) * 1000;
+        let start_height: u32;
+        // get
+        if i == 0 {
+            start_height = 0
+        } else {
+            start_height = (ckpt_height - 999) as u32;
+        }
+        println!("checkpt # {} = {:?} ... fetching headers...", ckpt_height, ckpt_header);
+        let ckpt_blk_hash = get_block_hash(state.clone(), ckpt_height).await.unwrap();
+        let headers = 
+            fetch_cf_headers_from_peers(
+                state.clone(),
+                state.clone().get_peers().await.unwrap(),
+                start_height,
+                ckpt_blk_hash,
+            ).await.unwrap();
+        assert!(headers.last().unwrap() == ckpt_header);
+        for (i, header) in headers.iter().enumerate() {
+            // println!("hash # {} = {:?}", i, header);
+            all_headers.push(*header);
+            let mut header_bin = Vec::new();
+            header.consensus_encode(
+                &mut header_bin, 
+            ).unwrap();
+            fh_tree.insert(i.to_le_bytes(), header_bin)?;
+        }
+    }
+
+    // fetch and verify filters against header chain
+    let mut previous_filter_header = FilterHeader::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap();
+    for batch in 0..=(count / 1000) {
+        // if batch % 1000 == 0 {
+            let start_height = batch * 1000;
+            let stop_height = start_height + 999;
+            let stop_hash = get_block_hash(state.clone(), stop_height).await?;
+            println!("getting filters start {:?} stop {:?} stop_hash {:?}", start_height, stop_height, stop_hash);
+            let filters = match fetch_filters_from_peers(
+                state.clone(), 
+                state.clone().get_peers().await.unwrap(), 
+                start_height as u32,
+                stop_hash
+            )
+            .await 
+            {
+                Some(filters) => {
+                    filters
+                },
+                None => {
+                    println!("None filter on fetch_filters_from_peers for hash = {}", stop_hash);
+                    return Err(anyhow!("None filter returned from fetch_filters_from_peers"))
+                },
+            };
+        // }
+        
+        // bf_tree.transaction(|bf_tree| {
+            use sled::transaction::ConflictableTransactionError::Abort;
+
+            for (i, (hash, filter) )in filters.iter().enumerate() {
+                let block_height = start_height + i;
+                let header_from_peers = all_headers[block_height];
+                let header_from_filter_calc = filter.filter_header(&previous_filter_header);
+                // println!("comparing headers {} and {}", header_from_peers, header_from_filter_calc);
+                assert!(header_from_peers == header_from_filter_calc);
+                if i == 0 {
+                    println!("inserting height {} {:?} filter {:?}", block_height, hash, filter.content.to_hex());
                 }
-                filter
-            },
-            None => {
-                println!("None filter on fetch_filter_from_peers for hash = {}", block_hash);
-                return Err(anyhow!("None filter returned from fetch_filter_from_peers"))
-            },
-            // Err(e) => {
-            //     println!("Error on fetch_filter for hash = {}", block_hash);
-            //     eprintln!("Error contents = {}", e);
-            //     return Err(e.into())
-            // },
-        };
-        bf_tree.insert(block_hash, filter.content.as_slice());
+                let mut hash_bin = Vec::new();
+                hash
+                    .consensus_encode(&mut hash_bin)
+                    .map_err(Abort)?;
+                bf_tree.insert(hash_bin, filter.content.as_slice())?;
+                previous_filter_header = header_from_peers;
+            }
+            // Ok(())
+        // })?;
     }
     // println!("count = {:?}", count);
     Ok(())
@@ -327,22 +232,14 @@ pub async fn build_filter_index_from_peers(state: Arc<State>) -> Result<(), Erro
 
 #[tokio::test]
 async fn test_peers() {
+    let start_time= std::time::SystemTime::now();
+    println!("starting at {:?}", start_time);
     let state = create_state::create_state().unwrap().arc();
     build_filter_index_from_peers(state).await;
+    println!("finished at {:?}", start_time.elapsed().unwrap());
     // let db: sled::Db = sled::open("bf").unwrap();
     // let utxo_tree = db.open_tree("utxo").unwrap();
     // let bf_tree = db.open_tree("bf").unwrap();
-}
-
-// #[test]
-#[tokio::test]
-async fn fetch_blocks() {
-    let state = create_state::create_state().unwrap().arc();
-    let block_hash: BlockHash = "000000000000000000048a890969858feffb5799cd8b3d181abd1a4fc650828e".parse().unwrap();
-    // println!("State = {:?}, BlockHash = {:?}", state, block_hash);
-    let filter = index_block_filter(state, block_hash).await.unwrap();
-    // println!("block = {:?}", block);
-    println!("filter = {:?}", filter);
 }
 
 #[tokio::test]
@@ -385,7 +282,7 @@ async fn print_single_filter() {
     let bf_tree = db.open_tree("bf").unwrap();
     // print single filter
     println!("getting block hash");
-    let block_hash: BlockHash = "0000000000000000000d0806d498ebe37c81960ba66987dd30f1eab9c9330c74"
+    let block_hash: BlockHash = "0000000000000000000aa87584856393a3cf61948c5ecc235f53922423d0f766"
     .parse()
     .unwrap();
     println!("getting filter");
@@ -425,33 +322,36 @@ async fn print_all_filters() {
     }
 }
 
-// fn db_test() {
-//     let filter_index = initialize_filter_index().unwrap();
-//     println!("filter_index = {:?}\n", filter_index);
 
-//     let db: sled::Db = sled::open("bfd").unwrap();
+#[tokio::test]
+async fn fetch_and_verify_filter_header_chain() {
+    let state = create_state::create_state().unwrap().arc();
+    let mut peers= state.clone().get_peers().await.unwrap();
+    let checkpts = 
+        fetch_cf_checkpts_from_peers(
+            state.clone(),
+            peers,
+            BlockHash::from_hex("0000000000000000000a94e99abfcac55d72702dbc967414fdb6f067ca76d969").unwrap(), // 671830
+        ).await.unwrap();
+    let mut all_headers = Vec::<FilterHeader>::new();
 
-//     // let block_hash: BlockHash = "00000000fd3ceb2404ff07a785c7fdcc76619edc8ed61bd25134eaa22084366a".parse().unwrap();
-//     // let block_filter = filter_index.get(&block_hash).unwrap().clone();
-//     for (block_hash, block_filter) in filter_index.iter() {
-//         println!("block_hash {:?} block_filter {:?}", block_hash, block_filter.content.as_slice());
-//         if db.contains_key(block_hash).unwrap() {
-//             println!("key already exists. skipping");
-//         }  else {
-//             println!("key does not exist, inserting");
-//             db.insert(block_hash, block_filter.content.as_slice());
-//             let block_filter_content_from_db = &db.get(block_hash).unwrap().unwrap();
-//             println!("block_filter_content_from_db = {:?}", block_filter_content_from_db);
-//             let block_filter_from_db = BlockFilter::new(&block_filter_content_from_db);
-//             println!("block_filter_from_db = {:?}", block_filter_from_db);
-//         }
-//     }
-
-//     for result in db.iter() {
-//         let (block_hash_bin, block_filter_bin) = result.unwrap();
-//         let block_hash = BlockHash::consensus_decode(&mut std::io::Cursor::new(
-//             block_hash_bin
-//         )).unwrap();
-//         println!("block_hash {:?} block_filter {:?}", block_hash, block_filter_bin.to_hex());
-//     }
-// }
+    // verify the filter header chain against the checkpoints
+    for (i, ckpt_header) in checkpts.iter().enumerate() {
+        let ckpt_height =  (i +1) * 1000;
+        let start_height = (ckpt_height - 999) as u32;
+        println!("checkpt # {} = {:?} ... fetching headers...", ckpt_height, ckpt_header);
+        let ckpt_blk_hash = get_block_hash(state.clone(), ckpt_height).await.unwrap();
+        let headers = 
+            fetch_cf_headers_from_peers(
+                state.clone(),
+                state.clone().get_peers().await.unwrap(),
+                start_height,
+                ckpt_blk_hash,
+            ).await.unwrap();
+        assert!(headers.last().unwrap() == ckpt_header);
+        for (i, header) in headers.iter().enumerate() {
+            println!("hash # {} = {:?}", i, header);
+            all_headers.push(*header);
+        }
+    }
+}

--- a/src/block_filters.rs
+++ b/src/block_filters.rs
@@ -1,0 +1,473 @@
+// #[macro_use]
+// extern crate sled;
+// use crate::client::{RpcResponse, GenericRpcMethod, RpcError};
+// use crate::client::{
+//     GenericRpcMethod, RpcError, RpcMethod, RpcRequest, RpcResponse, METHOD_NOT_ALLOWED_ERROR_CODE,
+//     METHOD_NOT_ALLOWED_ERROR_MESSAGE, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE,
+// };
+use crate::{
+    client::{
+        GenericRpcMethod, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE, RpcError, 
+        RpcRequest, 
+        RpcResponse
+    }, 
+    fetch_blocks::fetch_block, rpc_methods::{
+        GetBlockCount, GetBlockHash, 
+        // GetBlockHeader, GetBlockHeaderParams, GetBlockResult
+    }, 
+    // util::HexBytes
+};
+use crate::{
+    state::State, 
+    create_state
+};
+use std::{collections::HashMap, sync::Arc};
+// use std::io::Cursor;
+// use anyhow::Error;
+use anyhow::{anyhow, Context, Error};
+use bitcoin::{
+    Block, OutPoint, Script, 
+    // Transaction, TxMerkleNode, 
+    consensus::{Encodable, encode::deserialize, Decodable},
+    hash_types::{BlockHash, FilterHash}, 
+    hashes::hex::{FromHex, ToHex},
+    util::bip158::{
+        BlockFilter, 
+        // Error::UtxoMissing
+    }
+};
+
+use serde_json::Value;
+use sled::Tree;
+
+// fn get_block_filter_from_db(block_hash: BlockHash) -> Result<BlockFilter, Error> {
+//     println!("Block hash to_hex: {}", block_hash);
+//     // Ok(BlockFilter::new())
+// }
+
+
+/// fetches block filter from db, if matches, fetches block, and finds relevant txs, and returns them, along with merkle proofs
+// pub async fn get_relevant_txs(state: Arc<State>, block_hash: BlockHash, script: Script) -> Result<Vec<(Transaction, TxMerkleNode)>, Error> {
+// // pub async fn get_relevant_txs(state: Arc<State>, block_hash: BlockHash, script: Script) -> Result<Option<RpcResponse<GenericRpcMethod>>, RpcError> {
+//     println!("Getting relevant txs");
+//     // let res: Result<Vec<(Transaction, TxMerkleNode)> = Result(Vec<(Transaction, TxMerkleNode));
+//     let block: Block =
+//     match fetch_block(
+//         state.clone(),
+//         state.get_peers().await?,
+//         // serde_json::from_value(req.params[0].clone()).map_err(Error::from)?,
+//         block_hash,
+
+//     )
+//     .await
+//     {
+//         Ok(Some(block)) => {
+//             // Ok(Vec::new())
+//             block
+//                 .consensus_encode(&mut block_data)
+//                 .map_err(Error::from)?;
+//             let block_data = hex::encode(&block_data);
+//             Ok(Some(RpcResponse {
+//                 // id: req.id.clone(),
+//                 id: None,
+//                 result: Some(Value::String(block_data)),
+//                 error: None,
+//             }))
+//         }
+//         Ok(None) => {
+//             Ok(Vec::new())
+//         },
+        
+//         // Ok(Some(RpcResponse {
+//         //     id: None,
+//         //     result: None,
+//         //     error: Some(RpcError {
+//         //         code: MISC_ERROR_CODE,
+//         //         message: PRUNE_ERROR_MESSAGE.to_owned(),
+//         //         status: None,
+//         //     }),
+//         // })),
+//         Err(e) => Ok(Vec::new()),
+//     };
+//     Ok(Vec::new())
+// }
+
+// fn initialize_db() -> Result<HashMap<BlockHash, BlockFilter>, Error> {
+// fn initialize_filter_index() -> Result<HashMap<BlockHash, BlockFilter>, Error> {
+//     let data = r#"
+//     [
+//         ["Block Height,Block Hash,Block,[Prev Output Scripts for Block],Previous Basic Header,Basic Filter,Basic Header,Notes"],
+//         [0,"000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943","0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff001d1aa4ae180101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000",[],"0000000000000000000000000000000000000000000000000000000000000000","019dfca8","21584579b7eb08997773e5aeff3a7f932700042d0ed2a6129012b7d7ae81b750","Genesis block"],
+//         [2,"000000006c02c8ea6e4ff69651f7fcde348fb9d557a06e6957b65552002a7820","0100000006128e87be8b1b4dea47a7247d5528d2702c96826c7a648497e773b800000000e241352e3bec0a95a6217e10c3abb54adfa05abb12c126695595580fb92e222032e7494dffff001d00d235340101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0e0432e7494d010e062f503253482fffffffff0100f2052a010000002321038a7f6ef1c8ca0c588aa53fa860128077c9e6c11e6830f4d7ee4e763a56b7718fac00000000",[],"d7bdac13a59d745b1add0d2ce852f1a0442e8945fc1bf3848d3cbffd88c24fe1","0174a170","186afd11ef2b5e7e3504f2e8cbf8df28a1fd251fe53d60dff8b1467d1b386cf0",""],
+//         [3,"000000008b896e272758da5297bcd98fdc6d97c9b765ecec401e286dc1fdbe10","0100000020782a005255b657696ea057d5b98f34defcf75196f64f6eeac8026c0000000041ba5afc532aae03151b8aa87b65e1594f97504a768e010c98c0add79216247186e7494dffff001d058dc2b60101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0e0486e7494d0151062f503253482fffffffff0100f2052a01000000232103f6d9ff4c12959445ca5549c811683bf9c88e637b222dd2e0311154c4c85cf423ac00000000",[],"186afd11ef2b5e7e3504f2e8cbf8df28a1fd251fe53d60dff8b1467d1b386cf0","016cf7a0","8d63aadf5ab7257cb6d2316a57b16f517bff1c6388f124ec4c04af1212729d2a",""],
+//         [15007,"0000000038c44c703bae0f98cdd6bf30922326340a5996cc692aaae8bacf47ad","0100000002394092aa378fe35d7e9ac79c869b975c4de4374cd75eb5484b0e1e00000000eb9b8670abd44ad6c55cee18e3020fb0c6519e7004b01a16e9164867531b67afc33bc94fffff001d123f10050101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0e04c33bc94f0115062f503253482fffffffff0100f2052a01000000232103f268e9ae07e0f8cb2f6e901d87c510d650b97230c0365b021df8f467363cafb1ac00000000",[],"18b5c2b0146d2d09d24fb00ff5b52bd0742f36c9e65527abdb9de30c027a4748","013c3710","07384b01311867949e0c046607c66b7a766d338474bb67f66c8ae9dbd454b20e","Tx has non-standard OP_RETURN output followed by opcodes"],
+//         [49291,"0000000018b07dca1b28b4b5a119f6d6e71698ce1ed96f143f54179ce177a19c","02000000abfaf47274223ca2fea22797e44498240e482cb4c2f2baea088962f800000000604b5b52c32305b15d7542071d8b04e750a547500005d4010727694b6e72a776e55d0d51ffff001d211806480201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0d038bc0000102062f503253482fffffffff01a078072a01000000232102971dd6034ed0cf52450b608d196c07d6345184fcb14deb277a6b82d526a6163dac0000000001000000081cefd96060ecb1c4fbe675ad8a4f8bdc61d634c52b3a1c4116dee23749fe80ff000000009300493046022100866859c21f306538152e83f115bcfbf59ab4bb34887a88c03483a5dff9895f96022100a6dfd83caa609bf0516debc2bf65c3df91813a4842650a1858b3f61cfa8af249014730440220296d4b818bb037d0f83f9f7111665f49532dfdcbec1e6b784526e9ac4046eaa602204acf3a5cb2695e8404d80bf49ab04828bcbe6fc31d25a2844ced7a8d24afbdff01ffffffff1cefd96060ecb1c4fbe675ad8a4f8bdc61d634c52b3a1c4116dee23749fe80ff020000009400483045022100e87899175991aa008176cb553c6f2badbb5b741f328c9845fcab89f8b18cae2302200acce689896dc82933015e7230e5230d5cff8a1ffe82d334d60162ac2c5b0c9601493046022100994ad29d1e7b03e41731a4316e5f4992f0d9b6e2efc40a1ccd2c949b461175c502210099b69fdc2db00fbba214f16e286f6a49e2d8a0d5ffc6409d87796add475478d601ffffffff1e4a6d2d280ea06680d6cf8788ac90344a9c67cca9b06005bbd6d3f6945c8272010000009500493046022100a27400ba52fd842ce07398a1de102f710a10c5599545e6c95798934352c2e4df022100f6383b0b14c9f64b6718139f55b6b9494374755b86bae7d63f5d3e583b57255a01493046022100fdf543292f34e1eeb1703b264965339ec4a450ec47585009c606b3edbc5b617b022100a5fbb1c8de8aaaa582988cdb23622838e38de90bebcaab3928d949aa502a65d401ffffffff1e4a6d2d280ea06680d6cf8788ac90344a9c67cca9b06005bbd6d3f6945c8272020000009400493046022100ac626ac3051f875145b4fe4cfe089ea895aac73f65ab837b1ac30f5d875874fa022100bc03e79fa4b7eb707fb735b95ff6613ca33adeaf3a0607cdcead4cfd3b51729801483045022100b720b04a5c5e2f61b7df0fcf334ab6fea167b7aaede5695d3f7c6973496adbf1022043328c4cc1cdc3e5db7bb895ccc37133e960b2fd3ece98350f774596badb387201ffffffff23a8733e349c97d6cd90f520fdd084ba15ce0a395aad03cd51370602bb9e5db3010000004a00483045022100e8556b72c5e9c0da7371913a45861a61c5df434dfd962de7b23848e1a28c86ca02205d41ceda00136267281be0974be132ac4cda1459fe2090ce455619d8b91045e901ffffffff6856d609b881e875a5ee141c235e2a82f6b039f2b9babe82333677a5570285a6000000006a473044022040a1c631554b8b210fbdf2a73f191b2851afb51d5171fb53502a3a040a38d2c0022040d11cf6e7b41fe1b66c3d08f6ada1aee07a047cb77f242b8ecc63812c832c9a012102bcfad931b502761e452962a5976c79158a0f6d307ad31b739611dac6a297c256ffffffff6856d609b881e875a5ee141c235e2a82f6b039f2b9babe82333677a5570285a601000000930048304502205b109df098f7e932fbf71a45869c3f80323974a826ee2770789eae178a21bfc8022100c0e75615e53ee4b6e32b9bb5faa36ac539e9c05fa2ae6b6de5d09c08455c8b9601483045022009fb7d27375c47bea23b24818634df6a54ecf72d52e0c1268fb2a2c84f1885de022100e0ed4f15d62e7f537da0d0f1863498f9c7c0c0a4e00e4679588c8d1a9eb20bb801ffffffffa563c3722b7b39481836d5edfc1461f97335d5d1e9a23ade13680d0e2c1c371f030000006c493046022100ecc38ae2b1565643dc3c0dad5e961a5f0ea09cab28d024f92fa05c922924157e022100ebc166edf6fbe4004c72bfe8cf40130263f98ddff728c8e67b113dbd621906a601210211a4ed241174708c07206601b44a4c1c29e5ad8b1f731c50ca7e1d4b2a06dc1fffffffff02d0223a00000000001976a91445db0b779c0b9fa207f12a8218c94fc77aff504588ac80f0fa02000000000000000000",["5221033423007d8f263819a2e42becaaf5b06f34cb09919e06304349d950668209eaed21021d69e2b68c3960903b702af7829fadcd80bd89b158150c85c4a75b2c8cb9c39452ae","52210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179821021d69e2b68c3960903b702af7829fadcd80bd89b158150c85c4a75b2c8cb9c39452ae","522102a7ae1e0971fc1689bd66d2a7296da3a1662fd21a53c9e38979e0f090a375c12d21022adb62335f41eb4e27056ac37d462cda5ad783fa8e0e526ed79c752475db285d52ae","52210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179821022adb62335f41eb4e27056ac37d462cda5ad783fa8e0e526ed79c752475db285d52ae","512103b9d1d0e2b4355ec3cdef7c11a5c0beff9e8b8d8372ab4b4e0aaf30e80173001951ae","76a9149144761ebaccd5b4bbdc2a35453585b5637b2f8588ac","522103f1848b40621c5d48471d9784c8174ca060555891ace6d2b03c58eece946b1a9121020ee5d32b54d429c152fdc7b1db84f2074b0564d35400d89d11870f9273ec140c52ae","76a914f4fa1cc7de742d135ea82c17adf0bb9cf5f4fb8388ac"],"ed47705334f4643892ca46396eb3f4196a5e30880589e4009ef38eae895d4a13","0afbc2920af1b027f31f87b592276eb4c32094bb4d3697021b4c6380","b6d98692cec5145f67585f3434ec3c2b3030182e1cb3ec58b855c5c164dfaaa3","Tx pays to empty output script"],
+//         [180480,"00000000fd3ceb2404ff07a785c7fdcc76619edc8ed61bd25134eaa22084366a","020000006058aa080a655aa991a444bd7d1f2defd9a3bbe68aabb69030cf3b4e00000000d2e826bfd7ef0beaa891a7eedbc92cd6a544a6cb61c7bdaa436762eb2123ef9790f5f552ffff001d0002c90f0501000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0e0300c102024608062f503253482fffffffff01c0c6072a01000000232102e769e60137a4df6b0df8ebd387cca44c4c57ae74cc0114a8e8317c8f3bfd85e9ac00000000010000000381a0802911a01ffb025c4dea0bc77963e8c1bb46313b71164c53f72f37fe5248010000000151ffffffffc904b267833d215e2128bd9575242232ac2bc311550c7fc1f0ef6f264b40d14c010000000151ffffffffdf0915666649dba81886519c531649b7b02180b4af67d6885e871299e9d5f775000000000151ffffffff0180817dcb00000000232103bb52138972c48a132fc1f637858c5189607dd0f7fe40c4f20f6ad65f2d389ba4ac0000000001000000018da38b434fba82d66052af74fc5e4e94301b114d9bc03f819dc876398404c8b4010000006c493046022100fe738b7580dc5fb5168e51fc61b5aed211125eb71068031009a22d9bbad752c5022100be5086baa384d40bcab0fa586e4f728397388d86e18b66cc417dc4f7fa4f9878012103f233299455134caa2687bdf15cb0becdfb03bd0ff2ff38e65ec6b7834295c34fffffffff022ebc1400000000001976a9147779b7fba1c1e06b717069b80ca170e8b04458a488ac9879c40f000000001976a9142a0307cd925dbb66b534c4db33003dd18c57015788ac0000000001000000026139a62e3422a602de36c873a225c1d3ca5aeee598539ceecb9f0dc8d1ad0f83010000006b483045022100ad9f32b4a0a2ddc19b5a74eba78123e57616f1b3cfd72ce68c03ea35a3dda1f002200dbd22aa6da17213df5e70dfc3b2611d40f70c98ed9626aa5e2cde9d97461f0a012103ddb295d2f1e8319187738fb4b230fdd9aa29d0e01647f69f6d770b9ab24eea90ffffffff983c82c87cf020040d671956525014d5c2b28c6d948c85e1a522362c0059eeae010000006b4830450221009ca544274c786d30a5d5d25e17759201ea16d3aedddf0b9e9721246f7ef6b32e02202cfa5564b6e87dfd9fd98957820e4d4e6238baeb0f65fe305d91506bb13f5f4f012103c99113deac0d5d044e3ac0346abc02501542af8c8d3759f1382c72ff84e704f7ffffffff02c0c62d00000000001976a914ae19d27efe12f5a886dc79af37ad6805db6f922d88ac70ce2000000000001976a9143b8d051d37a07ea1042067e93efe63dbf73920b988ac000000000100000002be566e8cd9933f0c75c4a82c027f7d0c544d5c101d0607ef6ae5d07b98e7f1dc000000006b483045022036a8cdfd5ea7ebc06c2bfb6e4f942bbf9a1caeded41680d11a3a9f5d8284abad022100cacb92a5be3f39e8bc14db1710910ef7b395fa1e18f45d41c28d914fcdde33be012102bf59abf110b5131fae0a3ce1ec379329b4c896a6ae5d443edb68529cc2bc7816ffffffff96cf67645b76ceb23fe922874847456a15feee1655082ff32d25a6bf2c0dfc90000000006a47304402203471ca2001784a5ac0abab583581f2613523da47ec5f53df833c117b5abd81500220618a2847723d57324f2984678db556dbca1a72230fc7e39df04c2239942ba942012102925c9794fd7bb9f8b29e207d5fc491b1150135a21f505041858889fa4edf436fffffffff026c840f00000000001976a914797fb8777d7991d8284d88bfd421ce520f0f843188ac00ca9a3b000000001976a9146d10f3f592699265d10b106eda37c3ce793f7a8588ac00000000",["","","","76a9142903b138c24be9e070b3e73ec495d77a204615e788ac","76a91433a1941fd9a37b9821d376f5a51bd4b52fa50e2888ac","76a914e4374e8155d0865742ca12b8d4d14d41b57d682f88ac","76a914001fa7459a6cfc64bdc178ba7e7a21603bb2568f88ac","76a914f6039952bc2b307aeec5371bfb96b66078ec17f688ac"],"d34ef98386f413769502808d4bac5f20f8dfd5bffc9eedafaa71de0eb1f01489","0db414c859a07e8205876354a210a75042d0463404913d61a8e068e58a3ae2aa080026","c582d51c0ca365e3fcf36c51cb646d7f83a67e867cb4743fd2128e3e022b700c","Tx spends from empty output script"],
+//         [926485,"000000000000015d6077a411a8f5cc95caf775ccf11c54e27df75ce58d187313","0000002060bbab0edbf3ef8a49608ee326f8fd75c473b7e3982095e2d100000000000000c30134f8c9b6d2470488d7a67a888f6fa12f8692e0c3411fbfb92f0f68f67eedae03ca57ef13021acc22dc4105010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff2f0315230e0004ae03ca57043e3d1e1d0c8796bf579aef0c0000000000122f4e696e6a61506f6f6c2f5345475749542fffffffff038427a112000000001976a914876fbb82ec05caa6af7a3b5e5a983aae6c6cc6d688ac0000000000000000266a24aa21a9ed5c748e121c0fe146d973a4ac26fa4a68b0549d46ee22d25f50a5e46fe1b377ee00000000000000002952534b424c4f434b3acd16772ad61a3c5f00287480b720f6035d5e54c9efc71be94bb5e3727f10909001200000000000000000000000000000000000000000000000000000000000000000000000000100000000010145310e878941a1b2bc2d33797ee4d89d95eaaf2e13488063a2aa9a74490f510a0100000023220020b6744de4f6ec63cc92f7c220cdefeeb1b1bed2b66c8e5706d80ec247d37e65a1ffffffff01002d3101000000001976a9143ebc40e411ed3c76f86711507ab952300890397288ac0400473044022001dd489a5d4e2fbd8a3ade27177f6b49296ba7695c40dbbe650ea83f106415fd02200b23a0602d8ff1bdf79dee118205fc7e9b40672bf31563e5741feb53fb86388501483045022100f88f040e90cc5dc6c6189d04718376ac19ed996bf9e4a3c29c3718d90ffd27180220761711f16c9e3a44f71aab55cbc0634907a1fa8bb635d971a9a01d368727bea10169522103b3623117e988b76aaabe3d63f56a4fc88b228a71e64c4cc551d1204822fe85cb2103dd823066e096f72ed617a41d3ca56717db335b1ea47a1b4c5c9dbdd0963acba621033d7c89bd9da29fa8d44db7906a9778b53121f72191184a9fee785c39180e4be153ae00000000010000000120925534261de4dcebb1ed5ab1b62bfe7a3ef968fb111dc2c910adfebc6e3bdf010000006b483045022100f50198f5ae66211a4f485190abe4dc7accdabe3bc214ebc9ea7069b97097d46e0220316a70a03014887086e335fc1b48358d46cd6bdc9af3b57c109c94af76fc915101210316cff587a01a2736d5e12e53551b18d73780b83c3bfb4fcf209c869b11b6415effffffff0220a10700000000001976a91450333046115eaa0ac9e0216565f945070e44573988ac2e7cd01a000000001976a914c01a7ca16b47be50cbdbc60724f701d52d75156688ac00000000010000000203a25f58630d7a1ea52550365fd2156683f56daf6ca73a4b4bbd097e66516322010000006a47304402204efc3d70e4ca3049c2a425025edf22d5ca355f9ec899dbfbbeeb2268533a0f2b02204780d3739653035af4814ea52e1396d021953f948c29754edd0ee537364603dc012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff03a25f58630d7a1ea52550365fd2156683f56daf6ca73a4b4bbd097e66516322000000006a47304402202d96defdc5b4af71d6ba28c9a6042c2d5ee7bc6de565d4db84ef517445626e03022022da80320e9e489c8f41b74833dfb6a54a4eb5087cdb46eb663eef0b25caa526012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff0200e1f5050000000017a914b7e6f7ff8658b2d1fb107e3d7be7af4742e6b1b3876f88fc00000000001976a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac0000000001000000043ffd60d3818431c495b89be84afac205d5d1ed663009291c560758bbd0a66df5010000006b483045022100f344607de9df42049688dcae8ff1db34c0c7cd25ec05516e30d2bc8f12ac9b2f022060b648f6a21745ea6d9782e17bcc4277b5808326488a1f40d41e125879723d3a012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffffa5379401cce30f84731ef1ba65ce27edf2cc7ce57704507ebe8714aa16a96b92010000006a473044022020c37a63bf4d7f564c2192528709b6a38ab8271bd96898c6c2e335e5208661580220435c6f1ad4d9305d2c0a818b2feb5e45d443f2f162c0f61953a14d097fd07064012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff70e731e193235ff12c3184510895731a099112ffca4b00246c60003c40f843ce000000006a473044022053760f74c29a879e30a17b5f03a5bb057a5751a39f86fa6ecdedc36a1b7db04c022041d41c9b95f00d2d10a0373322a9025dba66c942196bc9d8adeb0e12d3024728012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff66b7a71b3e50379c8e85fc18fe3f1a408fc985f257036c34702ba205cef09f6f000000006a4730440220499bf9e2db3db6e930228d0661395f65431acae466634d098612fd80b08459ee022040e069fc9e3c60009f521cef54c38aadbd1251aee37940e6018aadb10f194d6a012103f7a897e4dbecab2264b21917f90664ea8256189ea725d28740cf7ba5d85b5763ffffffff0200e1f5050000000017a9148fc37ad460fdfbd2b44fe446f6e3071a4f64faa6878f447f0b000000001976a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac00000000",["a914feb8a29635c56d9cd913122f90678756bf23887687","76a914c01a7ca16b47be50cbdbc60724f701d52d75156688ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac","76a914913bcc2be49cb534c20474c4dee1e9c4c317e7eb88ac"],"8f13b9a9c85611635b47906c3053ac53cfcec7211455d4cb0d63dc9acc13d472","09027acea61b6cc3fb33f5d52f7d088a6b2f75d234e89ca800","546c574a0472144bcaf9b6aeabf26372ad87c7af7d1ee0dbfae5e099abeae49c","Duplicate pushdata 913bcc2be49cb534c20474c4dee1e9c4c317e7eb"],
+//         [987876,"0000000000000c00901f2049055e2a437c819d79a3d54fd63e6af796cd7b8a79","000000202694f74969fdb542090e95a56bc8aa2d646e27033850e32f1c5f000000000000f7e53676b3f12d5beb524ed617f2d25f5a93b5f4f52c1ba2678260d72712f8dd0a6dfe5740257e1a4b1768960101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1603e4120ff9c30a1c216900002f424d4920546573742fffffff0001205fa012000000001e76a914c486de584a735ec2f22da7cd9681614681f92173d83d0aa68688ac00000000",[],"fe4d230dbb0f4fec9bed23a5283e08baf996e3f32b93f52c7de1f641ddfd04ad","010c0b40","0965a544743bbfa36f254446e75630c09404b3d164a261892372977538928ed5","Coinbase tx has unparseable output script"],
+//         [1263442,"000000006f27ddfe1dd680044a34548f41bed47eba9e6f0b310da21423bc5f33","000000201c8d1a529c39a396db2db234d5ec152fa651a2872966daccbde028b400000000083f14492679151dbfaa1a825ef4c18518e780c1f91044180280a7d33f4a98ff5f45765aaddc001d38333b9a02010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff230352471300fe5f45765afe94690a000963676d696e6572343208000000000000000000ffffffff024423a804000000001976a914f2c25ac3d59f3d674b1d1d0a25c27339aaac0ba688ac0000000000000000266a24aa21a9edcb26cb3052426b9ebb4d19c819ef87c19677bbf3a7c46ef0855bd1b2abe83491012000000000000000000000000000000000000000000000000000000000000000000000000002000000000101d20978463906ba4ff5e7192494b88dd5eb0de85d900ab253af909106faa22cc5010000000004000000014777ff000000000016001446c29eabe8208a33aa1023c741fa79aa92e881ff0347304402207d7ca96134f2bcfdd6b536536fdd39ad17793632016936f777ebb32c22943fda02206014d2fb8a6aa58279797f861042ba604ebd2f8f61e5bddbd9d3be5a245047b201004b632103eeaeba7ce5dc2470221e9517fb498e8d6bd4e73b85b8be655196972eb9ccd5566754b2752103a40b74d43df244799d041f32ce1ad515a6cd99501701540e38750d883ae21d3a68ac00000000",["002027a5000c7917f785d8fc6e5a55adfca8717ecb973ebb7743849ff956d896a7ed"],"31d66d516a9eda7de865df29f6ef6cb8e4bf9309e5dac899968a9a62a5df61e3","0385acb4f0fe889ef0","4e6d564c2a2452065c205dd7eb2791124e0c4e0dbb064c410c24968572589dec","Includes witness data"],
+//         [1414221,"0000000000000027b2b3b3381f114f674f481544ff2be37ae3788d7e078383b1","000000204ea88307a7959d8207968f152bedca5a93aefab253f1fb2cfb032a400000000070cebb14ec6dbc27a9dfd066d9849a4d3bac5f674665f73a5fe1de01a022a0c851fda85bf05f4c19a779d1450102000000010000000000000000000000000000000000000000000000000000000000000000ffffffff18034d94154d696e6572476174653030310d000000f238f401ffffffff01c817a804000000000000000000",[],"5e5e12d90693c8e936f01847859404c67482439681928353ca1296982042864e","00","021e8882ef5a0ed932edeebbecfeda1d7ce528ec7b3daa27641acf1189d7b5dc","Empty data"]
+//     ]
+//     "#;
+
+//     let testdata = serde_json::from_str::<Value>(data).unwrap().as_array().unwrap().clone();
+//     let mut filters = HashMap::new();
+//     for t in testdata.iter().skip(1) {
+//         let block_hash = BlockHash::from_hex(&t.get(1).unwrap().as_str().unwrap()).unwrap();
+//         // println!("block hash: {:?}", block_hash);
+//         let block: Block = deserialize(&Vec::from_hex(&t.get(2).unwrap().as_str().unwrap()).unwrap()).unwrap();
+//         assert_eq!(block.block_hash(), block_hash);
+//         let scripts = t.get(3).unwrap().as_array().unwrap();
+//         let previous_filter_id = FilterHash::from_hex(&t.get(4).unwrap().as_str().unwrap()).unwrap();
+//         let filter_content = Vec::from_hex(&t.get(5).unwrap().as_str().unwrap()).unwrap();
+//         // println!("filter content: {:?}", filter_content);
+//         filters.insert(block_hash, BlockFilter::new(&filter_content));
+//         // filters.insert(block_hash, filter_content);
+//         let filter_id = FilterHash::from_hex(&t.get(6).unwrap().as_str().unwrap()).unwrap();
+//         // println!("filter id: {:?}", filter_id);
+
+//         let mut txmap = HashMap::new();
+//         let mut si = scripts.iter();
+//         for tx in block.txdata.iter().skip(1) {
+//             for input in tx.input.iter() {
+//                 txmap.insert(input.previous_output.clone(), Script::from(Vec::from_hex(si.next().unwrap().as_str().unwrap()).unwrap()));
+//             }
+//         }
+//         // println!("{:?}", get_block_filter(block_hash).unwrap());
+//     }
+//     Ok(filters)
+// }
+
+// fn get_block_filter(block_hash: BlockHash) -> Result<BlockFilter, Error> {
+//     println!("Getting block filter for hash: {}", block_hash);
+    // let filter = BlockFilter::new_script_filter(&block,
+    //                             |o| if let Some(s) = txmap.get(o) {
+    //                                 Ok(s.clone())
+    //                             } else {
+    //                                 Err(bitcoin::util::bip158::Error::UtxoMissing(o.clone()))
+    //                             }).unwrap();
+//     Ok(filter)
+// }
+
+/// fetches a block and stores its filter
+// pub async fn index_block_filter(state: Arc<State>, hash: BlockHash) -> Result<BlockFilter, bitcoin::Error> {
+pub async fn index_block_filter(state: Arc<State>, hash: BlockHash) -> Result<Block, bitcoin::Error> {
+    println!("State = {:?}, BlockHash = {:?}", state, hash);
+    let result =
+            fetch_block(state.clone(), state.clone().get_peers().await.unwrap(), hash);
+    let block = result.await.unwrap().unwrap();
+    // println!("block = {:?}", block);
+    // let filter = BlockFilter::new_script_filter(&block,
+    //     |o| if let Some(s) = Ok::<_, std::convert::Infallible>(o.script_pubkey.clone()) {
+    //         Ok(s.clone())
+    //     } else {
+    //         Err(UtxoMissing(o.clone()))
+    //     }).unwrap();
+    // Ok(filter)
+    Ok(block)
+}
+
+// fn get_script_for_coin (coin: &OutPoint) -> Result<Script, BlockFilterError> {
+fn get_script_for_coin (utxo_tree: Tree, coin: &OutPoint) -> Result<Script, bitcoin::util::bip158::Error> {
+    // let db: sled::Db = sled::open("bf").unwrap();
+    // let utxo_tree = db.open_tree("utxo").unwrap();
+    // println!("getting outpoint {}", coin);
+    let mut outpoint_bin = Vec::new();
+        coin.consensus_encode(
+        &mut outpoint_bin, 
+    ).unwrap();
+    let script_bin = match utxo_tree.get(outpoint_bin) {
+        Ok(Some(utxo)) => utxo,
+        Ok(None) => return Err(bitcoin::util::bip158::Error::UtxoMissing(coin.clone())),
+        Err(e) => return Err(bitcoin::util::bip158::Error::Io(std::io::Error::new(std::io::ErrorKind::Other, e))),
+    };
+    let script = Script::consensus_decode(&mut std::io::Cursor::new(
+        script_bin
+    )).unwrap();
+    // Ok(&utxo_tree.get(outpoint_bin).unwrap().unwrap())
+    Ok(script)
+}
+
+async fn get_block_hash(state: Arc<State>, block_height: usize) -> Result<BlockHash, RpcError> {
+    loop {
+        let result = match state
+        .rpc_client
+        .call(&RpcRequest {
+            id: None,
+            method: GetBlockHash,
+            params: (block_height,),
+        })
+        .await {
+            Ok(a) => return a.into_result(),
+            Err(e) => {
+                eprintln!("error getting block hash, retrying: {}", e);
+                std::thread::sleep(std::time::Duration::from_secs(1));
+            ()
+            },
+        };
+    }
+}
+
+async fn fetch_block_by_height(state:Arc<State>, block_height: usize) -> Result<Block, Error> {
+    if block_height == 134335 {
+        println!("fetching block hash for height 134335");
+    }
+
+    let block_hash = get_block_hash(state.clone(), block_height).await?;
+
+    if block_height == 134335 {
+        println!("successfully fetched block hash for 134335");
+    }
+    // let block_hash = result;
+    // if i % 1000 == 0 || i > 133999 {
+    if block_height == 134335 {
+        println!("fetching block height 134335 hash = {:x}", block_hash);
+    }
+    let block = match fetch_block(
+        state.clone(), 
+        state.clone().get_peers().await.unwrap(), 
+        block_hash
+    )
+    .await 
+    {
+        Ok(Some(block)) => {
+            if block_height == 134335 {
+                println!("Some block on fetch_block for hash = {}", block_hash);
+            }
+            block
+        },
+        Ok(None) => {
+            println!("None block on fetch_block for hash = {}", block_hash);
+            return Err(anyhow!("None block returned from fetch_block"))
+        },
+        Err(e) => {
+            println!("Error on fetch_block for hash = {}", block_hash);
+            return Err(e.into())
+        },
+    };
+    if block_height == 134335 {
+        println!("block height 134335 successful!");
+    }
+    // let block = result.await.unwrap().unwrap();
+    Ok(block)
+}
+
+async fn check_block_utxos(state: Arc<State>, utxo_tree: Tree, block_height: usize) -> Result<(), Error> {
+    let block = fetch_block_by_height(state, block_height).await.unwrap();
+    for tx in &block.txdata {
+        for vout in 0..tx.output.len() {
+            let outpoint = OutPoint::new(tx.txid(), vout as u32);
+            let script = tx.output[vout].script_pubkey.clone();
+            if tx.txid().to_string() == "03fa5038147f4df74c44541066f79bb76272144bbb56cd60c1cd5b44374494d9" {
+                println!("inserting outpoint {} and script {}", outpoint, script);
+            }
+            let mut outpoint_bin = Vec::new();
+            outpoint.consensus_encode(
+                &mut outpoint_bin, 
+            ).unwrap();
+            let mut script_bin = Vec::new();
+            script.consensus_encode(
+                &mut script_bin, 
+            ).unwrap();
+            if utxo_tree.contains_key(&outpoint_bin).unwrap() {
+                println!("outpoint found: {}", outpoint);
+            } else {
+                println!("outpoint missing, inserting: {}", outpoint);
+                // utxo_tree.insert(outpoint_bin, script_bin);
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn build_filter_index_and_utxo_set(state: Arc<State>) -> Result<(), Error> {
+    let result = state
+        .rpc_client
+        .call(&RpcRequest {
+            id: None,
+            method: GetBlockCount,
+            params: [(); 0],
+        })
+        .await?
+        .into_result();
+    let db: sled::Db = sled::open("bf").unwrap();
+    let utxo_tree = db.open_tree("utxo").unwrap();
+    let bf_tree = db.open_tree("bf").unwrap();
+    // for i in 0..=count {
+    let count = result.unwrap(); 
+    println!("count={}", count);
+    for i in 0..=count {
+    // for i in 0..=count {
+        // if i % 1000 == 0 || i > 133999 {
+        if i % 1000 == 0 {
+        // bf_tree.flush();
+        // utxo_tree.flush();
+            println!("requesting block hash for height {:?}", i);
+        }
+
+        // loop {
+        let block = fetch_block_by_height(
+            state.clone(), i
+        )
+        .await?;
+        // {
+        //     Ok(block) => block,
+        //     // Ok(None) => return Err(anyhow!("None block returned from fetch_block")),
+        //     Err(e) => {
+        //         println!("error on block height {}, retrying", i);
+        //         println!("error: {}", e);
+        //         // Err(e.into())
+        //         ()
+        //     },
+        // };
+        // }
+
+        // insert new utxos
+        for tx in &block.txdata {
+            for vout in 0..tx.output.len() {
+                let outpoint = OutPoint::new(tx.txid(), vout as u32);
+                let script = tx.output[vout].script_pubkey.clone();
+                // if tx.txid().to_string() == "03fa5038147f4df74c44541066f79bb76272144bbb56cd60c1cd5b44374494d9" {
+                // if i > 134334 {
+                //     // println!("inserting outpoint {} and script {}", outpoint, script);
+                //     println!("inserting outpoint {}", outpoint);
+                // }
+                let mut outpoint_bin = Vec::new();
+                outpoint.consensus_encode(
+                    &mut outpoint_bin, 
+                ).unwrap();
+                let mut script_bin = Vec::new();
+                script.consensus_encode(
+                    &mut script_bin, 
+                ).unwrap();
+                utxo_tree.insert(outpoint_bin, script_bin);
+            }
+        }
+
+        // calculate and store filter
+        let block_filter = BlockFilter::new_script_filter(
+            &block, |o| get_script_for_coin(utxo_tree.clone(), o)).unwrap();
+        // println!("filter = {:?}", block_filter.content.to_hex());
+        bf_tree.insert(block.block_hash(), block_filter.content.as_slice());
+
+        // delete spends from utxo db
+        for tx in &block.txdata {
+            if !tx.is_coin_base() {
+                if tx.input.len() > 0 {
+                    for vin in 0..tx.input.len() {
+                        // let outpoint = OutPoint::new(tx.txid(), vout as u32);
+                        let outpoint = tx.input[vin].previous_output;
+                        // if tx.txid().to_string() == "03fa5038147f4df74c44541066f79bb76272144bbb56cd60c1cd5b44374494d9" {
+                            // println!("deleting outpoint {} in block hash: {}", outpoint, block.block_hash());
+                        // }
+                        let mut outpoint_bin = Vec::new();
+                        outpoint.consensus_encode(
+                            &mut outpoint_bin, 
+                        ).unwrap();
+                        utxo_tree.remove(outpoint_bin);
+                    }
+                }
+            }
+        }
+
+    }
+    // println!("count = {:?}", count);
+    Ok(())
+}
+
+// #[test]
+#[tokio::test]
+async fn fetch_blocks() {
+    let state = create_state::create_state().unwrap().arc();
+    let block_hash: BlockHash = "000000000000000000048a890969858feffb5799cd8b3d181abd1a4fc650828e".parse().unwrap();
+    // println!("State = {:?}, BlockHash = {:?}", state, block_hash);
+    let filter = index_block_filter(state, block_hash).await.unwrap();
+    // println!("block = {:?}", block);
+    println!("filter = {:?}", filter);
+}
+
+#[tokio::test]
+async fn test_utxo() {
+    let state = create_state::create_state().unwrap().arc();
+    build_filter_index_and_utxo_set(state).await;
+    let db: sled::Db = sled::open("bf").unwrap();
+    let utxo_tree = db.open_tree("utxo").unwrap();
+    let bf_tree = db.open_tree("bf").unwrap();
+
+    
+    // //print all utxos
+    // let mut iter = utxo_tree.iter();
+    // // for i in 0..10{
+    //     // let result = iter[i].unwrap();
+    // for result in utxo_tree.iter() {
+    //     let (outpoint_bin, script_bin) = result.unwrap();
+    //     let outpoint = OutPoint::consensus_decode(&mut std::io::Cursor::new(
+    //         outpoint_bin
+    //     )).unwrap();
+    //     let script = Script::consensus_decode(&mut std::io::Cursor::new(
+    //         script_bin
+    //     )).unwrap();
+    //     println!("outpoint {} script {}", outpoint, script);
+    // }
+
+    // check utxos for block height
+    // check_block_utxos(state, utxo_tree, 134335).await;
+
+    // print single filter
+    // let block_hash: BlockHash = "00000000000007003fb47df9f520e292413501053b1e337a2349c093ffc6667e".parse().unwrap();
+    // let block_filter_bin = bf_tree.get(&block_hash).unwrap().unwrap();
+    // if block_filter_bin.is_none() {
+        // println!("Found None value in block {} {} {}")
+    // }
+    // println!("block_hash {:?} block_filter {:?}", block_hash, block_filter_bin.to_hex());
+
+    // // print all filters
+    // for result in bf_tree.iter() {
+    // // iter = bf_tree.iter();
+    // // for i in 0..10 {
+    // //     let result = iter[i].unwrap();
+    // // // }
+    //     let (block_hash_bin, block_filter_bin) = result.unwrap();
+    //     let block_hash = BlockHash::consensus_decode(&mut std::io::Cursor::new(
+    //         block_hash_bin
+    //     )).unwrap();
+    //     if block_hash.to_string() == "0000000099c744455f58e6c6e98b671e1bf7f37346bfd4cf5d0274ad8ee660cb" {
+
+    //         println!("block_hash {:?} block_filter {:?}", block_hash, block_filter_bin.to_hex());
+    //     }
+    // }
+
+}
+
+// fn db_test() {
+//     let filter_index = initialize_filter_index().unwrap();
+//     println!("filter_index = {:?}\n", filter_index);
+
+//     let db: sled::Db = sled::open("bfd").unwrap();
+
+//     // let block_hash: BlockHash = "00000000fd3ceb2404ff07a785c7fdcc76619edc8ed61bd25134eaa22084366a".parse().unwrap();
+//     // let block_filter = filter_index.get(&block_hash).unwrap().clone();
+    
+//     for (block_hash, block_filter) in filter_index.iter() {
+//         println!("block_hash {:?} block_filter {:?}", block_hash, block_filter.content.as_slice());
+//         if db.contains_key(block_hash).unwrap() {
+//             println!("key already exists. skipping");
+//         }  else {
+//             println!("key does not exist, inserting");
+//             db.insert(block_hash, block_filter.content.as_slice());
+//             let block_filter_content_from_db = &db.get(block_hash).unwrap().unwrap();
+//             println!("block_filter_content_from_db = {:?}", block_filter_content_from_db);
+//             let block_filter_from_db = BlockFilter::new(&block_filter_content_from_db);
+//             println!("block_filter_from_db = {:?}", block_filter_from_db);
+//         }
+//     }
+
+//     for result in db.iter() {
+//         let (block_hash_bin, block_filter_bin) = result.unwrap();
+//         let block_hash = BlockHash::consensus_decode(&mut std::io::Cursor::new(
+//             block_hash_bin
+//         )).unwrap();
+//         println!("block_hash {:?} block_filter {:?}", block_hash, block_filter_bin.to_hex());
+//     }
+// }
+

--- a/src/block_filters.rs
+++ b/src/block_filters.rs
@@ -433,7 +433,6 @@ async fn print_all_filters() {
 
 //     // let block_hash: BlockHash = "00000000fd3ceb2404ff07a785c7fdcc76619edc8ed61bd25134eaa22084366a".parse().unwrap();
 //     // let block_filter = filter_index.get(&block_hash).unwrap().clone();
-
 //     for (block_hash, block_filter) in filter_index.iter() {
 //         println!("block_hash {:?} block_filter {:?}", block_hash, block_filter.content.as_slice());
 //         if db.contains_key(block_hash).unwrap() {

--- a/src/block_filters.rs
+++ b/src/block_filters.rs
@@ -3,42 +3,20 @@ use crate::{client::{
         RpcRequest, 
         RpcResponse
     }, fetch_blocks::{fetch_block, fetch_filters_from_self}, rpc_methods::{
-        GetBlockCount, GetBlockHash, 
-        // GetBlockHeader, GetBlockHeaderParams, GetBlockResult
+        GetBlockCount, GetBlockHash, DeriveAddresses, DeriveAddressesParams,
     }};
 use crate::{
     state::State, 
     create_state
 };
-use std::{collections::HashMap, sync::Arc, time::SystemTime};
+use std::{collections::HashMap, hash::Hash, str::FromStr, sync::Arc, time::SystemTime};
 use anyhow::{anyhow, Context, Error};
-use bitcoin::{Block, FilterHeader, OutPoint, Script, consensus::{Encodable, encode::deserialize, Decodable}, hash_types::{BlockHash, FilterHash}, hashes::hex::{FromHex, ToHex}, util::bip158::{
-        BlockFilter, 
-    }};
-
-use enum_future::futures::stream::Filter;
-use serde_json::Value;
-use sled::Tree;
-
-fn get_script_for_coin (utxo_tree: Tree, coin: &OutPoint) -> Result<Script, bitcoin::util::bip158::Error> {
-    // let db: sled::Db = sled::open("bf").unwrap();
-    // let utxo_tree = db.open_tree("utxo").unwrap();
-    // println!("getting outpoint {}", coin);
-    let mut outpoint_bin = Vec::new();
-        coin.consensus_encode(
-        &mut outpoint_bin, 
-    ).unwrap();
-    let script_bin = match utxo_tree.get(outpoint_bin) {
-        Ok(Some(utxo)) => utxo,
-        Ok(None) => return Err(bitcoin::util::bip158::Error::UtxoMissing(coin.clone())),
-        Err(e) => return Err(bitcoin::util::bip158::Error::Io(std::io::Error::new(std::io::ErrorKind::Other, e))),
-    };
-    let script = Script::consensus_decode(&mut std::io::Cursor::new(
-        script_bin
-    )).unwrap();
-    // Ok(&utxo_tree.get(outpoint_bin).unwrap().unwrap())
-    Ok(script)
-}
+use bitcoin::{
+    Address, Block, FilterHeader, OutPoint, Script, Transaction, Txid, 
+    consensus::{Encodable, encode::deserialize, Decodable}, 
+    hash_types::{BlockHash, FilterHash}, 
+    hashes::hex::{FromHex, ToHex}, util::bip158::{BlockFilter,}
+};
 
 async fn get_block_hash(state: Arc<State>, block_height: usize) -> Result<BlockHash, RpcError> {
     loop {
@@ -69,21 +47,18 @@ async fn get_block_hashes(state: Arc<State>, start_height: usize, end_height: us
             params: (i,),
         });
     }
-    println!("reqs = {:?}", reqs);
     loop {
         let result = match state
         .rpc_client
         .call_batch(&reqs)
         .await {
             Ok(hash_responses) => {
-                println!("hash_responses = {:?}", hash_responses);
                 let mut hashes = Vec::<BlockHash>::new();
                 for hash_response in hash_responses {
                     hashes.push(
                         hash_response.into_result().unwrap()
                     );
                 }
-                // println!("hahes={:?}", hashes);
                 return Ok(hashes)
             },
             Err(e) => {
@@ -95,31 +70,25 @@ async fn get_block_hashes(state: Arc<State>, start_height: usize, end_height: us
     }
 }
 
-async fn fetch_block_by_height(state:Arc<State>, block_height: usize) -> Result<Block, Error> {
-    let block_hash = get_block_hash(state.clone(), block_height).await?;
-    let block = match fetch_block(
-        state.clone(), 
-        state.clone().get_peers().await.unwrap(), 
-        block_hash
-    )
-    .await 
-    {
-        Ok(Some(block)) => {
-            block
-        },
-        Ok(None) => {
-            println!("None block on fetch_block for hash = {}", block_hash);
-            return Err(anyhow!("None block returned from fetch_block"))
-        },
-        Err(e) => {
-            println!("Error on fetch_block for hash = {}", block_hash);
-            return Err(e.into())
-        },
-    };
-    Ok(block)
+pub async fn derive_addresses(state: Arc<State>, descriptor_string: String) -> Result<Vec<Address>, Error> {
+    let addresses = state
+      .rpc_client
+      .call(&RpcRequest {
+          id: None,
+          method: DeriveAddresses,
+          params: DeriveAddressesParams {
+              0: descriptor_string,
+              1: None,
+            //   1: Some([0, 1000].into()),
+          }
+      })
+      .await?
+      .into_result().unwrap()
+    ;
+    Ok(addresses)
 }
 
-pub async fn find_descriptor_blocks_from_rpc_filters(state: Arc<State>) -> Result<(), Error> {
+pub async fn find_blocks_from_rpc_filters(state: Arc<State>, descriptor_string: String) -> Result<Vec::<BlockHash>, Error> {
     println!("getting block count");
     let result = state
         .rpc_client
@@ -131,28 +100,22 @@ pub async fn find_descriptor_blocks_from_rpc_filters(state: Arc<State>) -> Resul
         .await?
         .into_result()
         ;
-    // let db: sled::Db = sled::open("bf").unwrap();
-    // let bf_tree = db.open_tree("bf").unwrap();
-    // let count = result.unwrap(); 
-    let count = 123; 
+    let count = result.unwrap(); 
     println!("count={}", count);
-
-    // fetch all filters from rpc
-    // for batch in 0..=(count / 1000) {
-    // use sled::transaction::ConflictableTransactionError::Abort;
-    let batch_size = 10;
+    let batch_size = 1000;
     let num_batches = count / batch_size;
+    let addresses = derive_addresses(state.clone(), descriptor_string).await.unwrap();
+    println!("addresses = {:?}", addresses);
+    let scripts: Vec::<Script> = addresses.iter().map(|a| a.payload.script_pubkey()).collect();
+    let mut match_count: i32 = 0;
+    let mut relevant_hashes = Vec::<BlockHash>::new();
     for batch in 0..=num_batches {
-        // let filter_batch = Vec::<(&[u8], &[u8])>::new();
-        // let mut db_batch = sled::Batch::default();
         let start_height = batch * batch_size;
         let end_height = match batch == num_batches {
             true => count,
             false => start_height + batch_size - 1
         };
         let hashes = get_block_hashes(state.clone(), start_height, end_height).await?;
-
-        // for i in start_height..end_height {
         let filters = match fetch_filters_from_self(
             &state.clone(),
             hashes.clone(),
@@ -168,149 +131,87 @@ pub async fn find_descriptor_blocks_from_rpc_filters(state: Arc<State>) -> Resul
             },
         };
     
-        // println!("inserting height {} {:?} filter {:?}", i, hash, filter.content.to_hex());
-        // if i % 1000 == 0 {
-            // bf_tree.flush_async().await?;
-        // }
-        let mut filter_batch = Vec::<(&[u8], &[u8])>::new();
-        println!("inserting starting height {} {:?} filter {:?}", start_height, &hashes[0], filters[0].content.to_hex());
-        println!("inserting ending height {} {:?} filter {:?}", end_height, &hashes.last().unwrap(), filters.last().unwrap().content.to_hex());
+        println!("inserting starting height {} {:?}", start_height, &hashes[0]);
+        // println!("inserting ending height {} {:?} filter {:?}", end_height, &hashes.last().unwrap(), filters.last().unwrap().content.to_hex());
         for i in 0..hashes.len() {
-            let mut hash_bin = Vec::new();
-            hashes[i]
-                .consensus_encode(&mut hash_bin).unwrap();
-            // bf_tree.insert(hash_bin, filters.content.as_slice())?;
-            // db_batch.insert(hash_bin, filters[i].content.as_slice());
+            let query = &scripts;
+            // println!("looking for script {:?} in hash {:?}", script, hashes[i]);
+            if filters[i].match_any(
+                &hashes[i], 
+                &mut query.iter().map(
+                    |s| s.as_bytes())
+                ).unwrap()
+            {
+                println!("match found in block with hash: {:?}", hashes[i]);
+                relevant_hashes.push(hashes[i]);
+                match_count += 1;
+            };
         }
-        // db.apply_batch(db_batch);
-        
     }
-    Ok(())
+    println!("{} blocks with relevant transations", match_count);
+    Ok(relevant_hashes)
+}
+
+
+pub async fn scan_blocks_for_txns(state: Arc<State>, relevant_hashes: Vec<BlockHash>, search_scripts: Vec<Script>) -> Result<Vec::<Transaction>, Error> {
+    let mut relevant_txns = Vec::<Transaction>::new();
+    for block_hash in relevant_hashes {
+        let block = match fetch_block(
+            state.clone(),
+            state.clone().get_peers().await.unwrap(),
+            block_hash,
+        )
+        .await
+        {
+            Ok(Some(block)) => block,
+            Ok(None) => return Err(anyhow!("None block returned from fetch_block")),
+            Err(e) => return Err(e.into()),
+        };
+        for txn in block.txdata {
+            let mut txn_match = false; 
+            for tx_out in &txn.output {
+                for script in &search_scripts {
+                    if &tx_out.script_pubkey == script {
+                        txn_match = true;
+                        println!("match found! tx hash: {:?}", txn.txid());
+                    }
+                }
+            }
+            if txn_match {
+                relevant_txns.push(txn);
+            }
+        }
+    }
+    Ok(relevant_txns)
 }
 
 #[tokio::test]
-async fn test_peers() {
+async fn test_scan() {
     let start_time= std::time::SystemTime::now();
     println!("starting at {:?}", start_time);
     let state = create_state::create_state().unwrap().arc();
-    find_descriptor_blocks_from_rpc_filters(state).await;
+    let descriptor_string: String = "addr(bc1q7nape377wsk3xh4g9st6mu9mnn6lf7uremmetj)#8hhmm2jt".into();
+    let addresses = derive_addresses(state.clone(), descriptor_string.clone()).await.unwrap();
+    let relevant_hashes = match find_blocks_from_rpc_filters(state.clone(), descriptor_string.clone()).await {
+        Ok(rbh) => rbh,
+        Err(e) => {
+            // eprintln!("error scanning block filters {}", e);
+            panic!("error scanning block filters {}", e);
+        },
+    };
+
+    let search_scripts = addresses.iter().map(|a| a.payload.script_pubkey()).collect();
+    let relevant_txns = scan_blocks_for_txns(state, relevant_hashes, search_scripts).await.unwrap();
+    let relevant_txids: Vec<Txid> = relevant_txns.iter().map(|t| t.txid()).collect();
+    println!("found {} relevant txns. hashes: {:?}", relevant_txns.len(), relevant_txids);
     println!("finished at {:?}", start_time.elapsed().unwrap());
     std::thread::sleep(std::time::Duration::from_secs(1));
-    // let db: sled::Db = sled::open("bf").unwrap();
-    // let utxo_tree = db.open_tree("utxo").unwrap();
-    // let bf_tree = db.open_tree("bf").unwrap();
-}
-
-// #[tokio::test]
-// async fn check_utxos_for_height() {
-//     let state = create_state::create_state().unwrap().arc();
-//     // build_filter_index_and_utxo_set(state).await;
-//     println!("opening bf");
-//     let db: sled::Db = sled::open("bf").unwrap();
-//     println!("opening utxo tree");
-//     let utxo_tree = db.open_tree("utxo").unwrap();
-//     // check utxos for block height
-//     let block_height = 278234;
-//     println!("about to check utxos for block {}", block_height);
-//     check_block_utxos(state, utxo_tree, block_height).await;
-// }
-
-#[tokio::test]
-async fn print_all_utxos() {
-    println!("opening bf");
-    let db: sled::Db = sled::open("bf").unwrap();
-    println!("opening utxo tree");
-    let utxo_tree = db.open_tree("utxo").unwrap();
-    //print all utxos
-    let mut iter = utxo_tree.iter();
-    // for i in 0..10{
-    // let result = iter[i].unwrap();
-    for result in utxo_tree.iter() {
-        let (outpoint_bin, script_bin) = result.unwrap();
-        let outpoint = OutPoint::consensus_decode(&mut std::io::Cursor::new(outpoint_bin)).unwrap();
-        let script = Script::consensus_decode(&mut std::io::Cursor::new(script_bin)).unwrap();
-        println!("outpoint {} script {}", outpoint, script);
-    }
 }
 
 #[tokio::test]
-async fn print_single_filter() {
-    println!("opening db");
-    let db: sled::Db = sled::open("bf").unwrap();
-    println!("opening bf_tree");
-    let bf_tree = db.open_tree("bf").unwrap();
-    // print single filter
-    println!("getting block hash");
-    let block_hash: BlockHash = "0000000000000000000aa87584856393a3cf61948c5ecc235f53922423d0f766"
-    .parse()
-    .unwrap();
-    println!("getting filter");
-    let block_filter_bin = bf_tree.get(&block_hash).unwrap().unwrap();
-    // if block_filter_bin.is_none() {
-    //     println!("Found None value in block");
-    // }
-    println!(
-        "block_hash {:?} block_filter {:?}",
-        block_hash,
-        block_filter_bin.to_hex()
-    );
+async fn scripts_from_addresses() {
+    let address = Address::from_str("bc1q7nape377wsk3xh4g9st6mu9mnn6lf7uremmetj").unwrap();
+    println!("output script = {:?}", address.payload.script_pubkey());
+    let address = Address::from_str("1PLKVvWUFGCYRNDzUQFXn1ErJ7bXbinzrM").unwrap();
+    println!("output script = {:?}", address.payload.script_pubkey());
 }
-
-#[tokio::test]
-async fn print_all_filters() {
-    let db: sled::Db = sled::open("bf").unwrap();
-    let bf_tree = db.open_tree("bf").unwrap();
-    // // print all filters
-    for result in bf_tree.iter() {
-        // iter = bf_tree.iter();
-        // for i in 0..10 {
-        //     let result = iter[i].unwrap();
-        // // }
-        let (block_hash_bin, block_filter_bin) = result.unwrap();
-        let block_hash =
-            BlockHash::consensus_decode(&mut std::io::Cursor::new(block_hash_bin)).unwrap();
-        if block_hash.to_string()
-            == "0000000099c744455f58e6c6e98b671e1bf7f37346bfd4cf5d0274ad8ee660cb"
-        {
-            println!(
-                "block_hash {:?} block_filter {:?}",
-                block_hash,
-                block_filter_bin.to_hex()
-            );
-        }
-    }
-}
-
-
-// #[tokio::test]
-// async fn fetch_and_verify_filter_header_chain() {
-//     let state = create_state::create_state().unwrap().arc();
-//     let mut peers= state.clone().get_peers().await.unwrap();
-//     let checkpts = 
-//         fetch_cf_checkpts_from_peers(
-//             state.clone(),
-//             peers,
-//             BlockHash::from_hex("0000000000000000000a94e99abfcac55d72702dbc967414fdb6f067ca76d969").unwrap(), // 671830
-//         ).await.unwrap();
-//     let mut all_headers = Vec::<FilterHeader>::new();
-
-//     // verify the filter header chain against the checkpoints
-//     for (i, ckpt_header) in checkpts.iter().enumerate() {
-//         let ckpt_height =  (i +1) * 1000;
-//         let start_height = (ckpt_height - 999) as u32;
-//         println!("checkpt # {} = {:?} ... fetching headers...", ckpt_height, ckpt_header);
-//         let ckpt_blk_hash = get_block_hash(state.clone(), ckpt_height).await.unwrap();
-//         let headers = 
-//             fetch_cf_headers_from_peers(
-//                 state.clone(),
-//                 state.clone().get_peers().await.unwrap(),
-//                 start_height,
-//                 ckpt_blk_hash,
-//             ).await.unwrap();
-//         assert!(headers.last().unwrap() == ckpt_header);
-//         for (i, header) in headers.iter().enumerate() {
-//             println!("hash # {} = {:?}", i, header);
-//             all_headers.push(*header);
-//         }
-//     }
-// }

--- a/src/client.rs
+++ b/src/client.rs
@@ -164,12 +164,9 @@ impl From<RpcError> for RpcResponse<GenericRpcMethod> {
 }
 impl<T: RpcMethod> RpcResponse<T> {
     pub fn into_result(self) -> Result<T::Response, RpcError> {
-        // println!("into_result called with error {:?}", self.error);
         match self.error {
             Some(e) => 
-            // Err(e)
             {
-                // println!("Error in into_result!");
                 Err(e)
             }
             ,
@@ -325,7 +322,6 @@ impl RpcClient {
         &self,
         req: &RpcRequest<T>,
     ) -> Result<RpcResponse<T>, ClientError> {
-        // println!("calling `call` with req method {:?}", req.method.as_str());
         let response = self
             .client
             .request(
@@ -336,8 +332,8 @@ impl RpcClient {
                     .body(serde_json::to_string(req)?.into())?,
             )
             .await?;
-        // println!("call complete! with req method {:?}", req.method.as_str());
         let status = response.status();
+        
         let body = to_bytes(response.into_body()).await?;
         let mut rpc_response: RpcResponse<T> =
             serde_json::from_slice(&body).map_err(|serde_error| {
@@ -355,7 +351,6 @@ impl RpcClient {
                     },
                 }
             })?;
-        // println!("deserialization complete! with req method {:?}", req.method.as_str());
         if let Some(ref mut error) = rpc_response.error {
             error.status = Some(status);
         }
@@ -366,9 +361,6 @@ impl RpcClient {
         &self,
         reqs: &Vec<RpcRequest<T>>,
     ) -> Result<Vec<RpcResponse<T>>, ClientError> {
-        // println!("calling `call` with req method {:?}", req.method.as_str());
-        // let mut rpc_responses = Vec::<RpcResponse<T>>::new();
-        // for req in reqs {
         let response = self
             .client
             .request(
@@ -379,7 +371,6 @@ impl RpcClient {
                     .body(serde_json::to_string(reqs)?.into())?,
             )
             .await?;
-        // println!("call complete! with req method {:?}", req.method.as_str());
         let status = response.status();
         let body = to_bytes(response.into_body()).await?;        
         let mut rpc_response: Vec<RpcResponse<T>> =
@@ -399,14 +390,6 @@ impl RpcClient {
                     },
                 }
             })?;
-        // for resp in &rpc_response {
-        //     if let Some(mut error) = &resp.error {
-        //         error.status = Some(status);
-        //     }
-        // }
-            // rpc_responses.push(rpc_response);
-        // }
-        // println!("deserialization complete! with req method {:?}", req.method.as_str());
         Ok(rpc_response)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -164,8 +164,15 @@ impl From<RpcError> for RpcResponse<GenericRpcMethod> {
 }
 impl<T: RpcMethod> RpcResponse<T> {
     pub fn into_result(self) -> Result<T::Response, RpcError> {
+        // println!("into_result called with error {:?}", self.error);
         match self.error {
-            Some(e) => Err(e),
+            Some(e) => 
+            // Err(e)
+            {
+                // println!("Error in into_result!");
+                Err(e)
+            }
+            ,
             None => Ok(self.result).transpose().unwrap_or_else(|| {
                 serde_json::from_value(Value::Null)
                     .map_err(Error::from)
@@ -313,10 +320,12 @@ impl RpcClient {
             }
         }
     }
+
     pub async fn call<T: RpcMethod + Serialize>(
         &self,
         req: &RpcRequest<T>,
     ) -> Result<RpcResponse<T>, ClientError> {
+        // println!("calling `call` with req method {:?}", req.method.as_str());
         let response = self
             .client
             .request(
@@ -327,6 +336,7 @@ impl RpcClient {
                     .body(serde_json::to_string(req)?.into())?,
             )
             .await?;
+        // println!("call complete! with req method {:?}", req.method.as_str());
         let status = response.status();
         let body = to_bytes(response.into_body()).await?;
         let mut rpc_response: RpcResponse<T> =
@@ -345,6 +355,7 @@ impl RpcClient {
                     },
                 }
             })?;
+        // println!("deserialization complete! with req method {:?}", req.method.as_str());
         if let Some(ref mut error) = rpc_response.error {
             error.status = Some(status);
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::SystemTime;  
 
 use anyhow::{anyhow, Error};
 use futures::{channel::mpsc, StreamExt, TryStreamExt};

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use std::time::SystemTime;
 use anyhow::{anyhow, Error};
 use futures::{channel::mpsc, StreamExt, TryStreamExt};
 use hyper::{
-    body::Bytes,
+    body::to_bytes,
     client::{Client, HttpConnector},
     header::{HeaderValue, AUTHORIZATION, CONTENT_LENGTH},
     Body, Method, Request, Response, StatusCode, Uri,
@@ -274,7 +274,7 @@ impl RpcClient {
                                 message: "internal server error".to_owned(),
                                 status: Some(StatusCode::INTERNAL_SERVER_ERROR),
                             });
-                        },
+                        }
                     };
 
                     let response = client
@@ -289,10 +289,7 @@ impl RpcClient {
                         )
                         .await
                         .map_err(Error::from)?;
-                    let body: Bytes =
-                        tokio::stream::StreamExt::collect::<Result<Bytes, _>>(response.into_body())
-                            .await
-                            .map_err(Error::from)?;
+                    let body = to_bytes(response.into_body()).await.map_err(Error::from)?;
                     let forwarded_res: Vec<RpcResponse<GenericRpcMethod>> =
                         serde_json::from_slice(body.as_ref())?;
                     Ok(idxs.into_iter().zip(forwarded_res).collect())
@@ -331,13 +328,21 @@ impl RpcClient {
             )
             .await?;
         let status = response.status();
-        let body: Bytes =
-            tokio::stream::StreamExt::collect::<Result<Bytes, _>>(response.into_body()).await?;
-        let mut rpc_response: RpcResponse<T> = serde_json::from_slice(&body)
-            .map_err(|serde_error| {
+        let body = to_bytes(response.into_body()).await?;
+        let mut rpc_response: RpcResponse<T> =
+            serde_json::from_slice(&body).map_err(|serde_error| {
                 match std::str::from_utf8(&body) {
-                    Ok(body) => ClientError::ParseResponseUtf8 { method: req.method.as_str().to_owned(), status: status, body: body.to_owned(), serde_error },
-                    Err(error) => ClientError::ResponseNotUtf8 { method: req.method.as_str().to_owned(), status: status, utf8_error: error, },
+                    Ok(body) => ClientError::ParseResponseUtf8 {
+                        method: req.method.as_str().to_owned(),
+                        status,
+                        body: body.to_owned(),
+                        serde_error,
+                    },
+                    Err(error) => ClientError::ResponseNotUtf8 {
+                        method: req.method.as_str().to_owned(),
+                        status,
+                        utf8_error: error,
+                    },
                 }
             })?;
         if let Some(ref mut error) = rpc_response.error {
@@ -354,13 +359,25 @@ pub enum ClientError {
     #[error("failed to load authentication data")]
     LoadAuth(#[from] AuthLoadError),
     #[error("hyper failed to process HTTP request")]
-    Hyper(#[from] hyper::error::Error),
+    Hyper(#[from] hyper::Error),
     #[error("invalid HTTP request")]
     Http(#[from] http::Error),
-    #[error("HTTP response (status: {status}) to method {method} can't be parsed as json, body: {body}")]
-    ParseResponseUtf8 { method: String, status: http::status::StatusCode, body: String, #[source] serde_error: serde_json::Error },
+    #[error(
+        "HTTP response (status: {status}) to method {method} can't be parsed as json, body: {body}"
+    )]
+    ParseResponseUtf8 {
+        method: String,
+        status: http::status::StatusCode,
+        body: String,
+        #[source]
+        serde_error: serde_json::Error,
+    },
     #[error("HTTP response (status: {status}) to method {method} is not UTF-8")]
-    ResponseNotUtf8 { method: String, status: http::status::StatusCode, utf8_error: std::str::Utf8Error, },
+    ResponseNotUtf8 {
+        method: String,
+        status: http::status::StatusCode,
+        utf8_error: std::str::Utf8Error,
+    },
 }
 
 impl From<ClientError> for RpcError {
@@ -416,13 +433,18 @@ impl AuthSource {
     }
 
     async fn load_from_file(path: &PathBuf) -> Result<String, AuthLoadError> {
-        tokio::fs::read_to_string(path).await.map(|mut cookie| {
-            if cookie.ends_with('\n') {
-                cookie.pop();
-            }
-            base64::encode(cookie)
-        })
-        .map_err(|error| AuthLoadError::Read { path: path.to_owned(), error, })
+        tokio::fs::read_to_string(path)
+            .await
+            .map(|mut cookie| {
+                if cookie.ends_with('\n') {
+                    cookie.pop();
+                }
+                base64::encode(cookie)
+            })
+            .map_err(|error| AuthLoadError::Read {
+                path: path.to_owned(),
+                error,
+            })
     }
 
     pub async fn try_load(&self) -> Result<HeaderValue, AuthLoadError> {
@@ -435,9 +457,15 @@ impl AuthSource {
                 let cache = cached.read().await.clone();
                 let modified = tokio::fs::metadata(&path)
                     .await
-                    .map_err(|error| AuthLoadError::Metadata { path: path.to_owned(), error, })?
+                    .map_err(|error| AuthLoadError::Metadata {
+                        path: path.to_owned(),
+                        error,
+                    })?
                     .modified()
-                    .map_err(|error| AuthLoadError::Modified { path: path.to_owned(), error, })?;
+                    .map_err(|error| AuthLoadError::Modified {
+                        path: path.to_owned(),
+                        error,
+                    })?;
                 match cache {
                     Some(cache) if modified == cache.0 => Ok(cache.1.clone()),
                     _ => {
@@ -456,11 +484,23 @@ impl AuthSource {
 #[derive(Debug, thiserror::Error)]
 pub enum AuthLoadError {
     #[error("failed to get metadata of file {path}")]
-    Metadata { path: PathBuf, #[source] error: std::io::Error, },
+    Metadata {
+        path: PathBuf,
+        #[source]
+        error: std::io::Error,
+    },
     #[error("failed to get modification time of file {path}")]
-    Modified { path: PathBuf, #[source] error: std::io::Error, },
+    Modified {
+        path: PathBuf,
+        #[source]
+        error: std::io::Error,
+    },
     #[error("failed to read file {path}")]
-    Read { path: PathBuf, #[source] error: std::io::Error, },
+    Read {
+        path: PathBuf,
+        #[source]
+        error: std::io::Error,
+    },
     #[error("invalid header value")]
     HeaderValue(#[from] http::header::InvalidHeaderValue),
 }

--- a/src/create_state.rs
+++ b/src/create_state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Error;
-use btc_rpc_proxy::{AuthSource, Peers, RpcClient, State, TorState};
+use crate::{AuthSource, Peers, RpcClient, State, TorState};
 use slog::Drain;
 use tokio::sync::RwLock;
 
@@ -18,7 +18,8 @@ pub fn create_state() -> Result<State, Error> {
     use slog::Level;
 
     let (config, _) =
-        Config::including_optional_config_files(std::iter::empty::<&str>()).unwrap_or_exit();
+        // Config::including_optional_config_files(std::iter::empty::<&str>()).unwrap_or_exit();
+        Config::including_optional_config_files(&["btc_rpc_proxy.toml"]).unwrap_or_exit();
 
     let log_level = match config.verbose {
         0 => Level::Critical,
@@ -63,7 +64,7 @@ pub fn create_state() -> Result<State, Error> {
         bind: (config.bind_address, config.bind_port).into(),
         rpc_client,
         tor,
-        users: btc_rpc_proxy::users::input::map_default(config.user, config.default_fetch_blocks),
+        users: crate::users::input::map_default(config.user, config.default_fetch_blocks),
         logger,
         peer_timeout: Duration::from_secs(config.peer_timeout),
         peers: RwLock::new(Arc::new(Peers::new())),

--- a/src/create_state.rs
+++ b/src/create_state.rs
@@ -19,7 +19,7 @@ pub fn create_state() -> Result<State, Error> {
 
     let (config, _) =
         // Config::including_optional_config_files(std::iter::empty::<&str>()).unwrap_or_exit();
-        Config::including_optional_config_files(&["btc_rpc_proxy.toml"]).unwrap_or_exit();
+        Config::including_optional_config_files(&["brp_config.toml"]).unwrap_or_exit();
 
     let log_level = match config.verbose {
         0 => Level::Critical,

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -43,8 +43,8 @@ lazy_static::lazy_static! {
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .unwrap()
                     .as_secs() as i64,
-                bitcoin::network::Address::new(&([0, 0, 0, 0], 8332).into(), ServiceFlags::NONE),
-                bitcoin::network::Address::new(&([0, 0, 0, 0], 8332).into(), ServiceFlags::NONE),
+                bitcoin::network::Address::new(&([127, 0, 0, 1], 8332).into(), ServiceFlags::NONE),
+                bitcoin::network::Address::new(&([127, 0, 0, 1], 8332).into(), ServiceFlags::NONE),
                 rand::random(),
                 format!("BTC RPC Proxy v{}", env!("CARGO_PKG_VERSION")),
                 0,

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -70,6 +70,9 @@ impl Peers {
             .map(|f| f.elapsed() > max_peer_age)
             .unwrap_or(true)
     }
+    pub fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
     pub async fn updated(client: &RpcClient) -> Result<Self, PeerUpdateError> {
         Ok(Self {
             peers: client

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -10,7 +10,6 @@ use bitcoin::{
     consensus::{Decodable, Encodable},
     hash_types::BlockHash,
     network::{
-        address::Address,
         constants::{Network::Bitcoin, ServiceFlags},
         message::{NetworkMessage, RawNetworkMessage},
         message_blockdata::Inventory,
@@ -21,18 +20,20 @@ use bitcoin::{
 use futures::FutureExt;
 use socks::Socks5Stream;
 
-use crate::client::{RpcClient, RpcError, ClientError, RpcRequest, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE};
+use crate::client::{
+    ClientError, RpcClient, RpcError, RpcRequest, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE,
+};
 use crate::rpc_methods::{GetBlock, GetBlockParams, GetPeerInfo, PeerAddressError};
 use crate::state::{State, TorState};
 
-type VersionMessageProducer = Box<dyn Fn(Address) -> RawNetworkMessage + Send + Sync>;
+type VersionMessageProducer = Box<dyn Fn() -> RawNetworkMessage + Send + Sync>;
 
 lazy_static::lazy_static! {
     static ref VER_ACK: RawNetworkMessage = RawNetworkMessage {
         magic: Bitcoin.magic(),
         payload: NetworkMessage::Verack,
     };
-    static ref VERSION_MESSAGE: VersionMessageProducer = Box::new(|addr| {
+    static ref VERSION_MESSAGE: VersionMessageProducer = Box::new(|| {
         use std::time::SystemTime;
         RawNetworkMessage {
             magic: Bitcoin.magic(),
@@ -42,8 +43,8 @@ lazy_static::lazy_static! {
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .unwrap()
                     .as_secs() as i64,
-                addr,
-                Address::new(&([127, 0, 0, 1], 8332).into(), ServiceFlags::NONE),
+                bitcoin::network::Address::new(&([0, 0, 0, 0], 8332).into(), ServiceFlags::NONE),
+                bitcoin::network::Address::new(&([0, 0, 0, 0], 8332).into(), ServiceFlags::NONE),
                 rand::random(),
                 format!("BTC RPC Proxy v{}", env!("CARGO_PKG_VERSION")),
                 0,
@@ -82,8 +83,8 @@ impl Peers {
                 .into_iter()
                 .filter(|p| !p.inbound)
                 .filter(|p| p.servicesnames.contains("NETWORK"))
-                .map(|p| p.into_address().map(Peer::new))
-                .collect::<Result<_, _>>()?,
+                .map(|p| Peer::new(Arc::new(p.addr)))
+                .collect(),
             fetched: Some(Instant::now()),
         })
     }
@@ -147,40 +148,19 @@ impl Write for BitcoinPeerConnection {
     }
 }
 impl BitcoinPeerConnection {
-    pub async fn connect(state: Arc<State>, addr: Address) -> Result<Self, Error> {
+    pub async fn connect(state: Arc<State>, addr: Arc<String>) -> Result<Self, Error> {
         tokio::time::timeout(
             state.peer_timeout,
             tokio::task::spawn_blocking(move || {
-                let mut stream = match (addr.socket_addr(), &state.tor) {
-                    (Ok(addr), Some(TorState { only: false, .. })) | (Ok(addr), None) => {
-                        BitcoinPeerConnection::ClearNet(TcpStream::connect(addr)?)
+                let mut stream = match &state.tor {
+                    Some(TorState { only, proxy })
+                        if *only || addr.split(":").next().unwrap().ends_with(".onion") =>
+                    {
+                        BitcoinPeerConnection::Tor(Socks5Stream::connect(proxy, &**addr)?)
                     }
-                    (Ok(addr), Some(tor)) => {
-                        BitcoinPeerConnection::Tor(Socks5Stream::connect(tor.proxy, addr)?)
-                    }
-                    (Err(_), Some(tor)) => BitcoinPeerConnection::Tor(Socks5Stream::connect(
-                        tor.proxy,
-                        (
-                            format!(
-                                "{}.onion",
-                                base32::encode(
-                                    base32::Alphabet::RFC4648 { padding: false },
-                                    &addr
-                                        .address
-                                        .iter()
-                                        .map(|n| *n)
-                                        .flat_map(|n| u16::to_be_bytes(n).to_vec())
-                                        .collect::<Vec<_>>()
-                                )
-                                .to_lowercase()
-                            )
-                            .as_str(),
-                            addr.port,
-                        ),
-                    )?),
-                    (Err(e), None) => return Err(e.into()),
+                    _ => BitcoinPeerConnection::ClearNet(TcpStream::connect(&*addr)?),
                 };
-                VERSION_MESSAGE(addr).consensus_encode(&mut stream)?;
+                VERSION_MESSAGE().consensus_encode(&mut stream)?;
                 stream.flush()?;
                 let _ =
                     bitcoin::network::message::RawNetworkMessage::consensus_decode(&mut stream)?; // version
@@ -197,12 +177,12 @@ impl BitcoinPeerConnection {
 }
 
 pub struct Peer {
-    addr: Address,
+    addr: Arc<String>,
     send: mpmc::Sender<BitcoinPeerConnection>,
     recv: mpmc::Receiver<BitcoinPeerConnection>,
 }
 impl Peer {
-    pub fn new(addr: Address) -> Self {
+    pub fn new(addr: Arc<String>) -> Self {
         let (send, recv) = mpmc::bounded(1);
         Peer { addr, send, recv }
     }
@@ -221,7 +201,7 @@ impl std::fmt::Debug for Peer {
 }
 
 pub struct PeerHandle {
-    addr: Address,
+    addr: Arc<String>,
     conn: Option<BitcoinPeerConnection>,
     send: mpmc::Sender<BitcoinPeerConnection>,
 }

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -6,15 +6,13 @@ use std::time::{Duration, Instant};
 
 use anyhow::Error;
 use async_channel as mpmc;
-use bitcoin::{Block, consensus::{Decodable, Encodable}, hash_types::BlockHash, hashes::hex::FromHex, network::{constants::{Network::Bitcoin, ServiceFlags}, message::{NetworkMessage, RawNetworkMessage}, message_blockdata::Inventory, message_filter::GetCFilters, message_network::VersionMessage}, util::bip158::BlockFilter};
+use bitcoin::{Block, consensus::{Decodable, Encodable}, hash_types::BlockHash, hashes::hex::FromHex, network::{address::Address, constants::{Network::Bitcoin, ServiceFlags}, message::{NetworkMessage, RawNetworkMessage}, message_blockdata::Inventory, message_filter::GetCFilters, message_network::VersionMessage}, util::bip158::{BlockFilter, BlockFilterReader}};
 use futures::FutureExt;
 use socks::Socks5Stream;
-// use time::delay_for;
-// use tokio::time;
+use tokio::time;
 
-use crate::{client::{ClientError, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE, RpcClient, RpcError, RpcRequest, RpcResponse}, rpc_methods::GetBlockFilter};
-use crate::create_state::create_state;
-use crate::rpc_methods::{GetBlock, GetBlockParams, GetPeerInfo, PeerAddressError};
+use crate::{client::{ClientError, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE, RpcClient, RpcError, RpcRequest, RpcResponse}, create_state::create_state};
+use crate::rpc_methods::{GetBlock, GetBlockFilter, GetBlockParams, GetPeerInfo, PeerAddressError};
 use crate::state::{State, TorState};
 
 type VersionMessageProducer = Box<dyn Fn() -> RawNetworkMessage + Send + Sync>;

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -6,24 +6,14 @@ use std::time::{Duration, Instant};
 
 use anyhow::Error;
 use async_channel as mpmc;
-use bitcoin::{
-    consensus::{Decodable, Encodable},
-    hash_types::BlockHash,
-    network::{
-        constants::{Network::Bitcoin, ServiceFlags},
-        message::{NetworkMessage, RawNetworkMessage},
-        message_blockdata::Inventory,
-        message_network::VersionMessage,
-    },
-    Block,
-};
+use bitcoin::{Block, consensus::{Decodable, Encodable}, hash_types::BlockHash, hashes::hex::FromHex, network::{constants::{Network::Bitcoin, ServiceFlags}, message::{NetworkMessage, RawNetworkMessage}, message_blockdata::Inventory, message_filter::GetCFilters, message_network::VersionMessage}, util::bip158::BlockFilter};
 use futures::FutureExt;
 use socks::Socks5Stream;
-use tokio::time;
+// use time::delay_for;
+// use tokio::time;
 
-use crate::client::{
-    ClientError, RpcClient, RpcError, RpcRequest, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE,
-};
+use crate::{client::{ClientError, MISC_ERROR_CODE, PRUNE_ERROR_MESSAGE, RpcClient, RpcError, RpcRequest, RpcResponse}, rpc_methods::GetBlockFilter};
+use crate::create_state::create_state;
 use crate::rpc_methods::{GetBlock, GetBlockParams, GetPeerInfo, PeerAddressError};
 use crate::state::{State, TorState};
 
@@ -97,6 +87,7 @@ impl Peers {
         )
     }
     pub fn handles<C: FromIterator<PeerHandle>>(&self) -> C {
+        println!("peers.handles... len = {}", self.peers.len());
         self.peers.iter().map(|p| p.handle()).collect()
     }
 }
@@ -597,7 +588,7 @@ async fn test_peers() {
     // if peers.len() == 0 {
     //     panic!();
     // }
-    time::delay_for(Duration::from_secs(10)).await;
+    tokio::time::sleep(Duration::from_secs(10)).await;
     let mut first_peer = &mut peers[0];
     let (filter, conn) = fetch_filter_from_peer(
         state.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate serde;
 extern crate configure_me;
 
 mod block_filters;
-mod create_state;
+pub mod create_state;
 pub mod client;
 pub mod fetch_blocks;
 pub mod proxy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,12 @@
 extern crate derive_more;
 #[macro_use]
 extern crate slog;
+extern crate serde;
+#[macro_use]
+extern crate configure_me;
 
+mod block_filters;
+mod create_state;
 pub mod client;
 pub mod fetch_blocks;
 pub mod proxy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use anyhow::Error;
 use futures::FutureExt;
 use hyper::{
     service::{make_service_fn, service_fn},
-    Server,
+    server::Server,
 };
 
 pub use crate::client::{AuthSource, RpcClient};

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate serde;
 
 use anyhow::Error;
 use btc_rpc_proxy;
+// use block_filters;
 
 mod create_state;
 
@@ -13,4 +14,5 @@ mod create_state;
 async fn main() -> Result<(), Error> {
     let state = create_state::create_state()?.arc();
     btc_rpc_proxy::main(state).await
+    // block_filters::main();
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -2,11 +2,10 @@ use std::sync::Arc;
 
 use anyhow::Error;
 use hyper::{
-    body::Bytes,
+    body::to_bytes,
     header::{AUTHORIZATION, WWW_AUTHENTICATE},
     Body, Method, Request, Response, StatusCode,
 };
-use tokio::stream::StreamExt;
 
 use crate::client::{RpcError, RpcResponse};
 use crate::state::State;
@@ -25,7 +24,7 @@ pub async fn proxy_request(
                 .get(AUTHORIZATION)
                 .and_then(|auth| state_local.users.get(auth))
             {
-                let body_data = body.collect::<Result<Bytes, _>>().await?;
+                let body_data = to_bytes(body).await?;
                 match serde_json::from_slice(body_data.as_ref()) {
                     Ok(req) => {
                         let state_local = state.clone();

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -111,7 +111,10 @@ impl<'de> Deserialize<'de> for GetBlockCount {
         }
     }
 }
+<<<<<<< HEAD
 
+=======
+>>>>>>> block filters first try
 #[derive(Debug)]
 pub struct GetBlockHash;
 

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -1,12 +1,7 @@
-use bitcoin::{
-    consensus::Decodable, 
-    hash_types::{BlockHash, FilterHeader}, 
-    network::{constants::ServiceFlags, Address}, 
-    util::{amount::Amount, bip158::BlockFilter}
-};
+use bitcoin::{Address, consensus::Decodable, hash_types::{BlockHash, FilterHeader}, network::{constants::ServiceFlags}, util::{amount::Amount, bip158::BlockFilter}};
 use linear_map::{set::LinearSet, LinearMap};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::Value;
+use serde_json::{Number, Value};
 
 use crate::client::RpcMethod;
 use crate::util::{Either, HexBytes};
@@ -170,6 +165,41 @@ impl<'de> Deserialize<'de> for GetBlockFilter {
     }
 }
 
+#[derive(Debug)]
+pub struct DeriveAddresses;
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeriveAddressesParams(
+    pub String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Option<Vec<usize>>,
+);
+impl RpcMethod for DeriveAddresses {
+    type Params = DeriveAddressesParams;
+    type Response = Vec<Address>;
+    fn as_str(&self) -> &'static str {
+        "deriveaddresses"
+    }
+}
+impl Serialize for DeriveAddresses {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_str().serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for DeriveAddresses {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s: &'de str = Deserialize::deserialize(deserializer)?;
+        if s == Self.as_str() {
+            Ok(Self)
+        } else {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(s),
+                &Self.as_str(),
+            ))
+        }
+    }
+}
+
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockHeaderResult {
@@ -209,6 +239,12 @@ pub struct GetBlockFilterResult {
     // pub header: FilterHeader,
     pub filter: String,
     pub header: String,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeriveAddressesResult {
+    pub addresses: Vec::<String>,
 }
 
 #[derive(Debug)]

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -111,10 +111,6 @@ impl<'de> Deserialize<'de> for GetBlockCount {
         }
     }
 }
-<<<<<<< HEAD
-
-=======
->>>>>>> block filters first try
 #[derive(Debug)]
 pub struct GetBlockHash;
 

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -77,6 +77,62 @@ impl<'de> Deserialize<'de> for GetBlockHeader {
         }
     }
 }
+#[derive(Debug)]
+pub struct GetBlockCount;
+
+impl RpcMethod for GetBlockCount {
+    type Params = [(); 0];
+    type Response = usize;
+    fn as_str(&self) -> &'static str {
+        "getblockcount"
+    }
+}
+impl Serialize for GetBlockCount {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_str().serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for GetBlockCount {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s: &'de str = Deserialize::deserialize(deserializer)?;
+        if s == Self.as_str() {
+            Ok(Self)
+        } else {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(s),
+                &Self.as_str(),
+            ))
+        }
+    }
+}
+#[derive(Debug)]
+pub struct GetBlockHash;
+
+impl RpcMethod for GetBlockHash {
+    type Params = (usize,);
+    type Response = BlockHash;
+    fn as_str(&self) -> &'static str {
+        "getblockhash"
+    }
+}
+impl Serialize for GetBlockHash {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_str().serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for GetBlockHash {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s: &'de str = Deserialize::deserialize(deserializer)?;
+        if s == Self.as_str() {
+            Ok(Self)
+        } else {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(s),
+                &Self.as_str(),
+            ))
+        }
+    }
+}
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -36,14 +36,24 @@ impl State {
         Arc::new(self)
     }
     pub async fn get_peers(self: Arc<Self>) -> Result<Vec<PeerHandle>, Error> {
-        let peers = self.peers.read().await.clone();
+        let mut peers = self.peers.read().await.clone();
         if peers.stale(self.max_peer_age) {
-            tokio::task::spawn(async move {
+            let handle = tokio::task::spawn(async move {
                 match Peers::updated(&self.rpc_client).await {
-                    Ok(peers) => *self.peers.write().await = Arc::new(peers),
-                    Err(error) => error!(self.logger, "failed to update peers"; "error" => #error),
+                    Ok(peers) => {
+                        let res = Arc::new(peers);
+                        *self.peers.write().await = res.clone();
+                        Ok(res)
+                    }
+                    Err(error) => {
+                        error!(self.logger, "failed to update peers"; "error" => #%error);
+                        Err(error)
+                    }
                 }
             });
+            if peers.is_empty() {
+                peers = handle.await??;
+            }
         }
         Ok(peers.handles())
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,6 +55,9 @@ impl State {
                 peers = handle.await??;
             }
         }
+        // if peers.peers.len() == 0 {
+        //     panic!("get_peers got no peers");
+        // }
         Ok(peers.handles())
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,8 +55,8 @@ impl State {
                 peers = handle.await??;
             }
         }
-        println!("get_peers: waiting 10 seconds...");
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        // println!("get_peers: waiting 10 seconds...");
+        // tokio::time::sleep(Duration::from_secs(10)).await;
         // if peers.peers.len() == 0 {
         //     panic!("get_peers got no peers");
         // }

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,6 +55,8 @@ impl State {
                 peers = handle.await??;
             }
         }
+        println!("get_peers: waiting 10 seconds...");
+        tokio::time::sleep(Duration::from_secs(10)).await;
         // if peers.peers.len() == 0 {
         //     panic!("get_peers got no peers");
         // }


### PR DESCRIPTION
This feature intercepts calls to the `rescanblockchain` RPC call, using block filters to locate transactions that may have been pruned, enabling users to import wallets with birth dates older than the prune height and successfully track transactions from those wallets.

This feature fetches block filters using the `getblockfilter` RPC call, which will be [available on pruned nodes](https://github.com/bitcoin/bitcoin/pull/15946) starting with [bitcoin core 0.22](https://github.com/bitcoin/bitcoin/milestone/47), which [should be released in August](https://github.com/bitcoin/bitcoin/issues/20851). It then scans the block filters for a vector of addresses (output scripts), derived from a descriptor using the `deriveaddresses` RPC call, making note of relevant block hashes. (This scanning portion may be replaced with a call to [the `scanblocks` RPC call](https://github.com/bitcoin/bitcoin/pull/20664) once it gets merged/released.)

It then fetches the blocks using the list of relevant block hashes and scans through them, finding relevant transactions.

TODO: 

1) Use `importprunedfunds` RPC call to import the relevant transactions to core. This will require creating merkle proofs for each transaction's inclusion in its block. 
2) Handle edges, such as the utxo set, mempool, and unpruned blocks
3) Actually intercept/handle the `rescanblockchain` call
4) Optimize/parallelize for low-resource hardware. Currently it takes about 90 minutes to scan from genesis to tip for a set of 1000 addresses on an M1 Macbook Air.