### PR TITLE
Feature/bip155 fix

### DIFF
--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -151,7 +151,13 @@ impl Write for BitcoinPeerConnection {
     }
 }
 impl BitcoinPeerConnection {
-    pub async fn connect(state: Arc<State>, addr: Arc<String>) -> Result<Self, Error> {
+    pub async fn connect(state: Arc<State>, mut addr: Arc<String>) -> Result<Self, Error> {
+        if !addr.contains(":") {
+            let addr_ref = &*addr;
+            let mut addr_owned = addr_ref.clone();
+            addr_owned.push_str(":8333");
+            addr = Arc::new(addr_owned);
+        }
         tokio::time::timeout(
             state.peer_timeout,
             tokio::task::spawn_blocking(move || {

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -153,10 +153,7 @@ impl Write for BitcoinPeerConnection {
 impl BitcoinPeerConnection {
     pub async fn connect(state: Arc<State>, mut addr: Arc<String>) -> Result<Self, Error> {
         if !addr.contains(":") {
-            let addr_ref = &*addr;
-            let mut addr_owned = addr_ref.clone();
-            addr_owned.push_str(":8333");
-            addr = Arc::new(addr_owned);
+            addr = Arc::new(format!("{}:8333", &*addr));
         }
         tokio::time::timeout(
             state.peer_timeout,
@@ -379,7 +376,7 @@ async fn fetch_block_from_peers(
     };
     if b.is_none() {
         b = match futures::poll!(blk_future) {
-            tokio::macros::support::Poll::Ready(Some(b)) => Some(b),
+            std::task::Poll::Ready(Some(b)) => Some(b),
             _ => None,
         };
     }


### PR DESCRIPTION
This PR fixes two minor issues:

- A race condition that sometimes didn't return a block even when it was received from the peer
- Failure to connect to a peer if its port was left out of bitcoin.conf. Since bitcoind itself defaults this case to 8333, proxy should do this too.

These issues were both discovered when adding a peer manually in bitcoin.conf.