### PR TITLE
add rpc params to debug logs

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -48,9 +48,10 @@ pub async fn proxy_request(
                                         debug!(
                                             state_local_ok.logger,
                                             "processed request";
+                                            "params" => serde_json::to_string(&req.params).unwrap_or_default(),
                                             "user" => name_local_ok,
                                             "method" => req.method.0.clone(),
-                                            "action" => action_description
+                                            "action" => action_description,
                                         );
                                         res
                                     })
@@ -58,6 +59,7 @@ pub async fn proxy_request(
                                         warn!(
                                             state_local_err.logger,
                                             "failed request";
+                                            "params" => serde_json::to_string(&req.params).unwrap_or_default(),
                                             "user" => name_local_err,
                                             "method" => req.method.0.clone(),
                                             "error_code" => error.code,


### PR DESCRIPTION
Adds rpc params to `DEBG` log entries. 

Looks like:

`Mar 25 14:57:27 embassy-30297ba3 13ca585518a5[1131]: Mar 25 14:57:27.704 DEBG processed request, action: INTERCEPTED, method: getblock, user: lnd, params: ["000000000000000000029d0c1db1e2fac03651f1244f49ae0c2649c85f681104"]`

Closes https://github.com/Start9Labs/btc-rpc-proxy-wrapper/issues/15.

Also exposed log levels as a UI config option in the wrapper