### PR TITLE
Reach i2p peers, skip the parse on verbosity 0, publish version-tagged images

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -23,17 +23,19 @@ jobs:
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          [ "$VERSION" == "master" ] && VERSION=latest
-          echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-        env:
-          IMAGE_ID: ${{ env.IMAGE_ID }}
-          VERSION: ${{ env.VERSION }}
+          REF=${{ github.ref }}
+          # A v* tag publishes an immutable `:vX.Y.Z` that packages can pin,
+          # and also moves `:latest`. Anything else (workflow_dispatch) only
+          # moves `:latest`.
+          if [[ "$REF" == refs/tags/v* ]]; then
+            TAGS="--tag $IMAGE_ID:${REF#refs/tags/} --tag $IMAGE_ID:latest"
+          else
+            TAGS="--tag $IMAGE_ID:latest"
+          fi
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build and push image
-        run: docker buildx build . --platform linux/amd64,linux/arm64,linux/riscv64 --tag $IMAGE_ID --label "runnumber=${GITHUB_RUN_ID}" --push
+        run: docker buildx build . --platform linux/amd64,linux/arm64,linux/riscv64 $TAGS --label "runnumber=${GITHUB_RUN_ID}" --push
       - name: Clean up Docker images
         run: docker image prune -f

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "btc-rpc-proxy"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 description = "Finer-grained permission management for bitcoind."
 edition = "2018"
 name = "btc-rpc-proxy"
-version = "0.4.0"
+version = "0.5.0"
 
 [lib]
 name = "btc_rpc_proxy"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ This means that you can run multiple services against your _pruned_ Bitcoin node
 
 A tradeoff to the proxy is speed and bandwidth. Every time the proxy needs to fetch a block not retained by your pruned node, it must reach out over the P2P network, consuming both Internet bandwidth and time.
 
+Fetching is a per-user permission. Set `fetch_blocks = true` on a `[user.*]`, or turn on the global `default_fetch_blocks` switch to grant it to every user that does not say otherwise — including the users derived from `passthrough_rpcauth` and `passthrough_rpccookie`, which carry no setting of their own and so are governed entirely by that switch.
+
+Two options tune what a fetch costs:
+
+* `max_peer_concurrency` caps how many peers are asked for the same block at once. The first valid answer wins, so leaving it unset asks _every_ eligible peer and pulls the block several times over.
+
+Peers are reached over clearnet, or through `tor_proxy` for `.onion` addresses. Reaching `.b32.i2p` peers additionally needs `i2p_proxy` pointed at an I2P SOCKSv5 proxy (i2pd's `socksproxy`, for instance); without one those peers cannot be used, as Tor cannot resolve them.
+
 ## Usage
 
 For security and performance reasons this application is written in Rust. Thus, you need a recent Rust compiler to compile it.
@@ -49,6 +57,7 @@ Especially in case of packaged software.
 ## Limitations
 
 * It uses `serde_json`, which allocates during deserialization (`Value`). Expect a bit lower performance than without proxy.
+* Only `getblock` verbosity 0 and 1 are intercepted. Verbosity 2 is forwarded to your node, so it still fails for a pruned block — and could not be answered faithfully anyway, since the per-input `fee` fields need undo data a pruned node no longer has.
 * Logging can't be configured yet.
 * No support for changing UID.
 * No support for Unix sockets.

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -102,6 +102,12 @@ optional = true
 doc = "The IP address and port of the Tor SOCKSv5 proxy to use for peer connections"
 
 [[param]]
+name = "i2p_proxy"
+type = "std::net::SocketAddr"
+optional = true
+doc = "The IP address and port of an I2P SOCKSv5 proxy, used to reach .i2p peers. Without it those peers are unreachable, as Tor cannot resolve them."
+
+[[param]]
 name = "tor_only"
 type = "bool"
 default = "false"

--- a/src/create_state.rs
+++ b/src/create_state.rs
@@ -130,6 +130,7 @@ pub fn create_state() -> Result<(State, SocketAddr), Error> {
         State {
             rpc_client,
             tor,
+            i2p_proxy: config.i2p_proxy,
             users: btc_rpc_proxy::users::input::map_default(users, config.default_fetch_blocks),
             logger,
             peer_timeout: Duration::from_secs(config.peer_timeout),

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -18,6 +18,7 @@ use bitcoin::{
     Block,
 };
 use futures::FutureExt;
+use hyper::body::Bytes;
 use socks::Socks5Stream;
 
 use crate::client::{
@@ -107,46 +108,46 @@ pub enum PeerUpdateError {
 }
 
 pub enum BitcoinPeerConnection {
-    ClearNet(TcpStream),
-    Tor(Socks5Stream),
+    Direct(TcpStream),
+    Proxied(Socks5Stream),
 }
 impl Read for BitcoinPeerConnection {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self {
-            BitcoinPeerConnection::ClearNet(a) => a.read(buf),
-            BitcoinPeerConnection::Tor(a) => a.read(buf),
+            BitcoinPeerConnection::Direct(a) => a.read(buf),
+            BitcoinPeerConnection::Proxied(a) => a.read(buf),
         }
     }
 }
 impl Write for BitcoinPeerConnection {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self {
-            BitcoinPeerConnection::ClearNet(a) => a.write(buf),
-            BitcoinPeerConnection::Tor(a) => a.write(buf),
+            BitcoinPeerConnection::Direct(a) => a.write(buf),
+            BitcoinPeerConnection::Proxied(a) => a.write(buf),
         }
     }
     fn flush(&mut self) -> std::io::Result<()> {
         match self {
-            BitcoinPeerConnection::ClearNet(a) => a.flush(),
-            BitcoinPeerConnection::Tor(a) => a.flush(),
+            BitcoinPeerConnection::Direct(a) => a.flush(),
+            BitcoinPeerConnection::Proxied(a) => a.flush(),
         }
     }
     fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
         match self {
-            BitcoinPeerConnection::ClearNet(a) => a.write_vectored(bufs),
-            BitcoinPeerConnection::Tor(a) => a.write_vectored(bufs),
+            BitcoinPeerConnection::Direct(a) => a.write_vectored(bufs),
+            BitcoinPeerConnection::Proxied(a) => a.write_vectored(bufs),
         }
     }
     fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
         match self {
-            BitcoinPeerConnection::ClearNet(a) => a.write_all(buf),
-            BitcoinPeerConnection::Tor(a) => a.write_all(buf),
+            BitcoinPeerConnection::Direct(a) => a.write_all(buf),
+            BitcoinPeerConnection::Proxied(a) => a.write_all(buf),
         }
     }
     fn write_fmt(&mut self, fmt: std::fmt::Arguments<'_>) -> std::io::Result<()> {
         match self {
-            BitcoinPeerConnection::ClearNet(a) => a.write_fmt(fmt),
-            BitcoinPeerConnection::Tor(a) => a.write_fmt(fmt),
+            BitcoinPeerConnection::Direct(a) => a.write_fmt(fmt),
+            BitcoinPeerConnection::Proxied(a) => a.write_fmt(fmt),
         }
     }
 }
@@ -158,13 +159,22 @@ impl BitcoinPeerConnection {
         tokio::time::timeout(
             state.peer_timeout,
             tokio::task::spawn_blocking(move || {
-                let mut stream = match &state.tor {
-                    Some(TorState { only, proxy })
-                        if *only || addr.split(":").next().unwrap().ends_with(".onion") =>
-                    {
-                        BitcoinPeerConnection::Tor(Socks5Stream::connect(proxy, &**addr)?)
+                // bitcoind reports i2p peers as `<base32>.b32.i2p:0`, which is
+                // neither routable nor resolvable outside i2p, so those need
+                // their own SOCKS proxy — Tor's cannot reach them.
+                let host = addr.rsplit_once(':').map_or(&**addr, |(host, _)| host);
+                let mut stream = if host.ends_with(".i2p") {
+                    let proxy = state.i2p_proxy.as_ref().ok_or_else(|| {
+                        anyhow::anyhow!("no i2p proxy configured, cannot reach {}", addr)
+                    })?;
+                    BitcoinPeerConnection::Proxied(Socks5Stream::connect(proxy, &**addr)?)
+                } else {
+                    match &state.tor {
+                        Some(TorState { only, proxy }) if *only || host.ends_with(".onion") => {
+                            BitcoinPeerConnection::Proxied(Socks5Stream::connect(proxy, &**addr)?)
+                        }
+                        _ => BitcoinPeerConnection::Direct(TcpStream::connect(&*addr)?),
                     }
-                    _ => BitcoinPeerConnection::ClearNet(TcpStream::connect(&*addr)?),
                 };
                 VERSION_MESSAGE().consensus_encode(&mut stream)?;
                 stream.flush()?;
@@ -248,7 +258,8 @@ impl std::ops::DerefMut for RecyclableConnection {
     }
 }
 
-async fn fetch_block_from_self(state: &State, hash: BlockHash) -> Result<Option<Block>, RpcError> {
+/// The block as bitcoind serialized it, or `None` if bitcoind has pruned it.
+async fn fetch_block_from_self(state: &State, hash: BlockHash) -> Result<Option<Bytes>, RpcError> {
     match state
         .rpc_client
         .call(&RpcRequest {
@@ -260,12 +271,9 @@ async fn fetch_block_from_self(state: &State, hash: BlockHash) -> Result<Option<
         .into_result()
     {
         Ok(b) => Ok(Some(
-            Block::consensus_decode(&mut std::io::Cursor::new(
-                b.as_left()
-                    .ok_or_else(|| anyhow::anyhow!("unexpected response for getblock"))?
-                    .as_ref(),
-            ))
-            .map_err(Error::from)?,
+            b.into_left()
+                .ok_or_else(|| anyhow::anyhow!("unexpected response for getblock"))?
+                .into_inner(),
         )),
         Err(e) if e.code == MISC_ERROR_CODE && e.message == PRUNE_ERROR_MESSAGE => Ok(None),
         Err(e) => Err(e),
@@ -383,25 +391,46 @@ async fn fetch_block_from_peers(
     b
 }
 
+/// The consensus-serialized block, from the local node if it still has it and
+/// from peers otherwise. Callers wanting `getblock` verbosity 0 use this
+/// directly and never pay to parse the block.
+pub async fn fetch_block_raw(
+    state: Arc<State>,
+    peers: Vec<PeerHandle>,
+    hash: BlockHash,
+) -> Result<Option<Bytes>, RpcError> {
+    if let Some(block) = fetch_block_from_self(&*state, hash).await? {
+        return Ok(Some(block));
+    }
+    debug!(
+        state.logger,
+        "Block is pruned from Core, attempting fetch from peers.";
+        "block_hash" => %hash
+    );
+    let block = match fetch_block_from_peers(state.clone(), peers, hash).await {
+        Some(block) => block,
+        None => {
+            error!(state.logger, "Could not fetch block from peers."; "block_hash" => %hash);
+            return Ok(None);
+        }
+    };
+    let mut serialized = Vec::new();
+    block
+        .consensus_encode(&mut serialized)
+        .map_err(Error::from)?;
+    Ok(Some(Bytes::from(serialized)))
+}
+
 pub async fn fetch_block(
     state: Arc<State>,
     peers: Vec<PeerHandle>,
     hash: BlockHash,
 ) -> Result<Option<Block>, RpcError> {
-    Ok(match fetch_block_from_self(&*state, hash).await? {
-        Some(block) => Some(block),
-        None => {
-            debug!(
-                state.logger,
-                "Block is pruned from Core, attempting fetch from peers.";
-                "block_hash" => %hash
-            );
-            if let Some(block) = fetch_block_from_peers(state.clone(), peers, hash).await {
-                Some(block)
-            } else {
-                error!(state.logger, "Could not fetch block from peers."; "block_hash" => %hash);
-                None
-            }
-        }
+    Ok(match fetch_block_raw(state, peers, hash).await? {
+        Some(block) => Some(
+            Block::consensus_decode(&mut std::io::Cursor::new(block.as_ref()))
+                .map_err(Error::from)?,
+        ),
+        None => None,
     })
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,6 +20,7 @@ pub struct TorState {
 pub struct State {
     pub rpc_client: RpcClient,
     pub tor: Option<TorState>,
+    pub i2p_proxy: Option<SocketAddr>,
     pub users: Users,
     pub logger: Logger,
     pub peer_timeout: Duration,

--- a/src/users.rs
+++ b/src/users.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Error;
-use bitcoin::consensus::Encodable;
 use hyper::{header::HeaderValue, StatusCode};
 use serde_json::Value;
 
@@ -11,7 +10,7 @@ use crate::client::{
     METHOD_NOT_ALLOWED_ERROR_CODE, METHOD_NOT_ALLOWED_ERROR_MESSAGE, MISC_ERROR_CODE,
     PRUNE_ERROR_MESSAGE,
 };
-use crate::fetch_blocks::fetch_block;
+use crate::fetch_blocks::{fetch_block, fetch_block_raw};
 use crate::rpc_methods::{GetBlock, GetBlockHeader, GetBlockHeaderParams, GetBlockResult};
 use crate::state::State;
 
@@ -230,25 +229,18 @@ impl User {
                 {
                     match params.get(1).unwrap_or(&1_u64.into()) {
                         Value::Number(ref n) if n.as_u64() == Some(0) => {
-                            match fetch_block(
+                            match fetch_block_raw(
                                 state.clone(),
                                 state.get_peers().await?,
                                 serde_json::from_value(params[0].clone()).map_err(Error::from)?,
                             )
                             .await
                             {
-                                Ok(Some(block)) => {
-                                    let mut block_data = Vec::new();
-                                    block
-                                        .consensus_encode(&mut block_data)
-                                        .map_err(Error::from)?;
-                                    let block_data = hex::encode(&block_data);
-                                    Ok(Some(RpcResponse {
-                                        id: req.id.clone(),
-                                        result: Some(Value::String(block_data)),
-                                        error: None,
-                                    }))
-                                }
+                                Ok(Some(block)) => Ok(Some(RpcResponse {
+                                    id: req.id.clone(),
+                                    result: Some(Value::String(hex::encode(&block))),
+                                    error: None,
+                                })),
                                 Ok(None) => Ok(Some(RpcResponse {
                                     id: req.id.clone(),
                                     result: None,

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,12 @@ use serde::{
 #[derive(Debug)]
 pub struct HexBytes(Bytes);
 
+impl HexBytes {
+    pub fn into_inner(self) -> Bytes {
+        self.0
+    }
+}
+
 impl std::ops::Deref for HexBytes {
     type Target = Bytes;
 


### PR DESCRIPTION
Found while diagnosing [lnd-startos#175](https://github.com/Start9Labs/lnd-startos/issues/175), where LND's channel graph never finished syncing against a pruned bitcoind. The root cause was on the packaging side — `bitcoin-core-startos` never set `default_fetch_blocks`, so every passthrough-authenticated client resolved to `fetch_blocks = false` and this proxy forwarded `getblock` straight through to the pruned node. That fix is a separate PR against the package. These are the improvements that surfaced while reading this code to confirm it.

## An i2p transport

bitcoind reports i2p peers as `<base32>.b32.i2p:0`. Nothing but an i2p router can reach those: dialed directly they fail to resolve, and Tor cannot resolve them either. They were still passing the `NETWORK` service filter, so they were counted as eligible peers and then always failed — burning a concurrency slot on a DNS timeout each time.

`i2p_proxy` points at an I2P SOCKSv5 proxy (i2pd's `socksproxy`, for instance) and `.i2p` peers are routed through it. Without the option they now fail immediately with a clear message rather than timing out. `BitcoinPeerConnection`'s variants are renamed `Direct`/`Proxied` in the same change, since a proxied socket no longer implies Tor.

The one thing I could not verify without a live i2pd: whether its SOCKS proxy accepts a target port of `0`. The address is passed through exactly as bitcoind reported it rather than rewritten on a guess. Worth a live test before relying on this path.

## No parse on verbosity 0

`getblock <hash> 0` asks for the serialized block, but the interceptor was decoding bitcoind's response into a `Block` and immediately re-encoding it — parsing every transaction of every block on a path that only needs the bytes. This is the common case on a pruned node, since it is what btcd's `rpcclient` (and therefore LND) sends. `fetch_block_raw` carries the bytes through untouched; verbosity 1, which genuinely needs a parsed block, decodes once at the end.

## Version-tagged images

`ghcr.yml` computed `VERSION` from the pushed ref and then never used it, building with `--tag $IMAGE_ID`. Every `v*` tag only ever overwrote `:latest`, which is why no version-tagged image exists and why the StartOS packages consume a moving `:latest`. It now publishes `:vX.Y.Z` **and** `:latest` on a tag.

Also worth knowing: `v0.4.3` sits on the pre-squash PR branch rather than on master (`git diff master v0.4.3` is empty). Future tags should be cut on master.

`Cargo.toml` goes `0.4.0` → `0.5.0`; it had drifted behind the tags, and it feeds the P2P user agent string.

## Notes for review

- No new tests: the i2p path needs a live SOCKS proxy to exercise, and the verbosity-0 change is a refactor of an existing path. The 7 existing tests pass and the release build is clean.
- The three pre-existing `cargo fmt` deviations (`build.rs`, `proxy.rs`, `util.rs`) are left alone to keep the diff reviewable — this repo has never been rustfmt-clean.
- `getblock` verbosity 2 remains uncovered, now documented as a limitation. It could not be answered faithfully for a pruned block anyway: the per-input `fee` fields need undo data a pruned node no longer has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
