### PR TITLE
fix: keep getblock working when the peer list cannot be built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "btc-rpc-proxy"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 description = "Finer-grained permission management for bitcoind."
 edition = "2018"
 name = "btc-rpc-proxy"
-version = "0.5.0"
+version = "0.5.1"
 
 [lib]
 name = "btc_rpc_proxy"

--- a/src/client.rs
+++ b/src/client.rs
@@ -187,7 +187,9 @@ impl From<Error> for RpcError {
     fn from(e: Error) -> Self {
         RpcError {
             code: MISC_ERROR_CODE,
-            message: format!("{}", e),
+            // Alternate form, so the source chain travels with the message —
+            // the outermost context alone rarely names what actually broke.
+            message: format!("{:#}", e),
             status: None,
         }
     }

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -396,7 +396,6 @@ async fn fetch_block_from_peers(
 /// directly and never pay to parse the block.
 pub async fn fetch_block_raw(
     state: Arc<State>,
-    peers: Vec<PeerHandle>,
     hash: BlockHash,
 ) -> Result<Option<Bytes>, RpcError> {
     if let Some(block) = fetch_block_from_self(&*state, hash).await? {
@@ -407,6 +406,9 @@ pub async fn fetch_block_raw(
         "Block is pruned from Core, attempting fetch from peers.";
         "block_hash" => %hash
     );
+    // Resolved here rather than by the caller so that a failure to enumerate
+    // peers can only ever affect blocks Core no longer has.
+    let peers = state.clone().get_peers().await?;
     let block = match fetch_block_from_peers(state.clone(), peers, hash).await {
         Some(block) => block,
         None => {
@@ -421,12 +423,8 @@ pub async fn fetch_block_raw(
     Ok(Some(Bytes::from(serialized)))
 }
 
-pub async fn fetch_block(
-    state: Arc<State>,
-    peers: Vec<PeerHandle>,
-    hash: BlockHash,
-) -> Result<Option<Block>, RpcError> {
-    Ok(match fetch_block_raw(state, peers, hash).await? {
+pub async fn fetch_block(state: Arc<State>, hash: BlockHash) -> Result<Option<Block>, RpcError> {
+    Ok(match fetch_block_raw(state, hash).await? {
         Some(block) => Some(
             Block::consensus_decode(&mut std::io::Cursor::new(block.as_ref()))
                 .map_err(Error::from)?,

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -109,36 +109,19 @@ pub struct GetBlockResult {
 #[derive(Debug)]
 pub struct GetPeerInfo;
 
-// https://docs.rs/bitcoincore-rpc-json/0.12.0/bitcoincore_rpc_json/struct.GetPeerInfoResult.html
+/// Only the fields `Peers::updated` selects on. Every other key Core emits is
+/// left to serde to ignore: naming one here makes it mandatory, and Core drops
+/// or conditionalizes keys between releases — `startingheight` went behind
+/// `-deprecatedrpc` in 31.0, and `addrbind` is emitted only for a valid bind
+/// address.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PeerInfo {
-    /// Peer index
-    pub id: u64,
     /// The IP address and port of the peer
     pub addr: String,
-    /// Bind address of the connection to the peer
-    pub addrbind: String,
-    /// Local address as reported by the peer
-    pub addrlocal: Option<String>,
-    /// The services offered
-    // TODO: use a type for services
-    pub services: String,
     /// The services offered
     pub servicesnames: LinearSet<String>,
-    /// The peer version, such as 70001
-    pub version: u64,
-    /// The string version
-    pub subver: String,
     /// Inbound (true) or Outbound (false)
     pub inbound: bool,
-    /// The starting height (block) of the peer
-    pub startingheight: i64,
-    /// The last header we have in common with this peer
-    pub synced_headers: i64,
-    /// The last block we have in common with this peer
-    pub synced_blocks: i64,
-    /// The heights of blocks we're currently asking from this peer
-    pub inflight: Vec<u64>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -312,5 +295,75 @@ impl<'de> Deserialize<'de> for GetBlockchainInfo {
                 &Self.as_str(),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PeerInfo;
+
+    /// One `getpeerinfo` entry exactly as Bitcoin Core v31.1 emits it for an
+    /// outbound clearnet peer. Core 31.0 put `startingheight` behind
+    /// `-deprecatedrpc=startingheight`; naming it in `PeerInfo` made every
+    /// peer-list refresh fail, which took `getblock` down with it.
+    const CORE_31_PEER: &str = r#"{
+      "id": 7,
+      "addr": "203.0.113.9:8333",
+      "addrbind": "10.0.3.5:44212",
+      "network": "ipv4",
+      "services": "0000000000000409",
+      "servicesnames": ["NETWORK", "WITNESS", "NETWORK_LIMITED"],
+      "relaytxes": true,
+      "last_inv_sequence": 0,
+      "inv_to_send": 0,
+      "lastsend": 1755096000,
+      "lastrecv": 1755096001,
+      "last_transaction": 1755095990,
+      "last_block": 1755095900,
+      "bytessent": 123456,
+      "bytesrecv": 654321,
+      "conntime": 1755090000,
+      "timeoffset": 0,
+      "pingtime": 0.041,
+      "minping": 0.039,
+      "version": 70016,
+      "subver": "/Satoshi:31.1.0/",
+      "inbound": false,
+      "bip152_hb_to": false,
+      "bip152_hb_from": false,
+      "presynced_headers": -1,
+      "synced_headers": 962297,
+      "synced_blocks": 962297,
+      "inflight": [],
+      "addr_relay_enabled": true,
+      "addr_processed": 100,
+      "addr_rate_limited": 0,
+      "permissions": [],
+      "minfeefilter": 0.00001000,
+      "bytessent_per_msg": { "version": 126 },
+      "bytesrecv_per_msg": { "version": 126 },
+      "connection_type": "outbound-full-relay",
+      "transport_protocol_type": "v2",
+      "session_id": "abc"
+    }"#;
+
+    #[test]
+    fn parses_core_31_peer() {
+        let peer: PeerInfo = serde_json::from_str(CORE_31_PEER).expect("failed to parse");
+        assert_eq!(peer.addr, "203.0.113.9:8333");
+        assert!(!peer.inbound);
+        assert!(peer.servicesnames.contains("NETWORK"));
+    }
+
+    /// Core omits `addrbind` when the bind address is not valid, and drops or
+    /// conditionalizes other keys between releases. None of that may break the
+    /// peer list.
+    #[test]
+    fn tolerates_omitted_optional_keys() {
+        let stripped = CORE_31_PEER
+            .replace(r#""addrbind": "10.0.3.5:44212","#, "")
+            .replace(r#""pingtime": 0.041,"#, "")
+            .replace(r#""session_id": "abc""#, r#""session_id": """#);
+        serde_json::from_str::<PeerInfo>(&stripped).expect("failed to parse");
     }
 }

--- a/src/users.rs
+++ b/src/users.rs
@@ -231,7 +231,6 @@ impl User {
                         Value::Number(ref n) if n.as_u64() == Some(0) => {
                             match fetch_block_raw(
                                 state.clone(),
-                                state.get_peers().await?,
                                 serde_json::from_value(params[0].clone()).map_err(Error::from)?,
                             )
                             .await
@@ -269,14 +268,7 @@ impl User {
                                         .await?
                                         .into_result()
                                 },
-                                async {
-                                    fetch_block(
-                                        state.clone(),
-                                        state.clone().get_peers().await?,
-                                        hash,
-                                    )
-                                    .await
-                                }
+                                async { fetch_block(state.clone(), hash).await }
                             ) {
                                 Ok((header, Some(block))) => Ok(Some(RpcResponse {
                                     id: req.id.clone(),


### PR DESCRIPTION
Fixes the regression reported in [Start9Labs/bitcoin-core-startos#270](https://github.com/Start9Labs/bitcoin-core-startos/issues/270): on a pruned **Bitcoin Core 31.x** node every `getblock` through the proxy fails, including for blocks Core has on disk.

## What broke

Core **31.0** moved `startingheight` out of `getpeerinfo` unless `-deprecatedrpc=startingheight` is set. It was unconditional through 30.x:

```cpp
obj.pushKV("startingheight", statestats.m_starting_height);   // <= v30.0
if (IsDeprecatedRPCEnabled("startingheight")) { … }           // v31.0+
```

`PeerInfo` named that field as mandatory, so on 31.x `getpeerinfo` never deserializes. `Peers::updated` returns `ClientError::ParseResponseUtf8`, wrapped in `PeerUpdateError::Client`, whose `Display` is the five words users saw: `failed to call Bitcoin RPC`.

That alone should have cost only the pruned-block fetches. What made it total is that `User::intercept` resolved the peer list **as an argument**:

```rust
fetch_block_raw(state.clone(), state.get_peers().await?, hash).await
```

so it ran before `fetch_block_from_self` ever asked Core for the block — and because the cached peer list starts empty, `get_peers` propagates the error instead of logging it in the background, permanently. Result: every `getblock` at verbosity 0 or 1 failed on a pruned 31.x node, and since a pruned node puts bitcoind on loopback and the proxy on 8332, that reached every dependent service. Verbosity 2 isn't intercepted, which is why it kept working and made the symptom look like a `getblock`-specific auth or connectivity fault.

## What changed

**`PeerInfo` declares only what it selects on.** `Peers::updated` reads `addr`, `servicesnames` and `inbound`; the other ten fields were decoration that serde nonetheless demanded. Naming a key makes it mandatory, and Core adds, drops and conditionalizes keys between releases — so this also fixes `addrbind`, which Core emits only for a valid bind address and which would have failed identically.

**The peer list is resolved inside `fetch_block_raw`,** after Core reports the block pruned. `fetch_block_raw` was already local-first; now the peer lookup sits behind that check too, so a fetch-side failure can only ever affect a block the node no longer has. This is suggestion (1) from the issue.

**`RpcError::from(anyhow::Error)` formats `{:#}`.** The serde error naming the missing field existed the whole time and was dropped one frame from the caller. With the chain attached this reads as `failed to call Bitcoin RPC: HTTP response (status: 200) to method getpeerinfo can't be parsed as json, body: …`. Suggestion (2).

Two regression tests parse a real Core 31.1 `getpeerinfo` entry, one intact and one with the optional keys stripped. Both fail against the old struct with `missing field \`startingheight\`` / `missing field \`addrbind\``.

Version bumped to `0.5.1`; tagging `v0.5.1` publishes the pinnable image.

## Note for whoever picks this up next

Verbosity 1 still reconstructs its result from the raw block plus `getblockheader` even when Core has the block, rather than passing through. That predates this PR and isn't a correctness problem, but passthrough-first — intercepting only once Core answers "pruned" — would be strictly better and needs a restructure of `send`/`intercept` that didn't belong in a fix this urgent.

Downstream, `bitcoin-core-startos` needs the image re-pinned on all four Core branches and both Knots branches (the `addrbind` case applies to every one of them), and the proxy started with `--verbose --verbose` — at the default the `verbose` counter maps to `slog::Level::Critical`, so the `error!("failed to update peers")` line was filtered out and this cost the reporter a full SSH bisect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)