### PR TITLE
Fix witness-stripped blocks and a Nagle stall in the peer fetcher; make it testable off mainnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,6 @@ dependencies = [
  "http",
  "hyper",
  "itertools",
- "lazy_static",
  "linear-map",
  "parse_arg",
  "serde",
@@ -556,12 +555,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "btc-rpc-proxy"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 description = "Finer-grained permission management for bitcoind."
 edition = "2018"
 name = "btc-rpc-proxy"
-version = "0.5.1"
+version = "0.6.0"
 
 [lib]
 name = "btc_rpc_proxy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ hyper = { version = "0.14.4", features = [
   "tcp",
 ] }
 itertools = "0.10.0"
-lazy_static = "1.4.0"
 linear-map = { version = "1.2.0", features = ["serde_impl"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"

--- a/README.md
+++ b/README.md
@@ -30,8 +30,13 @@ Fetching is a per-user permission. Set `fetch_blocks = true` on a `[user.*]`, or
 Two options tune what a fetch costs:
 
 * `max_peer_concurrency` caps how many peers are asked for the same block at once. The first valid answer wins, so leaving it unset asks _every_ eligible peer and pulls the block several times over.
+* `max_peer_age` is how many seconds a peer list is reused before `getpeerinfo` is called for a fresh one (300 by default).
+
+Only peers advertising `NETWORK` and `WITNESS` are asked, since a fetched block is served with its witness data and checked against the witness commitment in its own coinbase.
 
 Peers are reached over clearnet, or through `tor_proxy` for `.onion` addresses. Reaching `.b32.i2p` peers additionally needs `i2p_proxy` pointed at an I2P SOCKSv5 proxy (i2pd's `socksproxy`, for instance); without one those peers cannot be used, as Tor cannot resolve them.
+
+`network` must match the chain bitcoind is on — it selects the p2p magic bytes and the default peer port, and a peer on another network drops the connection rather than answering, so getting it wrong makes every pruned block unfetchable. Accepted values are `bitcoin` (the default), `testnet`, `signet` and `regtest`. These are **not** the names Core uses in `chain=`: a node started with `chain=main` needs `network = "bitcoin"` here, and `chain=test` needs `network = "testnet"`. `testnet4` is not supported.
 
 ## Usage
 

--- a/btc_rpc_proxy.toml
+++ b/btc_rpc_proxy.toml
@@ -1,6 +1,8 @@
 bitcoind_user = "bitcoinrpc"
 bitcoind_password = "taxation is theft"
 bind_address = "127.0.0.1"
+# Must match bitcoind's chain: bitcoin (default), testnet, signet or regtest.
+# network = "bitcoin"
 
 [user.public]
 password = "public"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -79,6 +79,12 @@ argument = false
 doc = "Map of user names to user configs. Each user must specify `password` field and an array of allowed calls named `allowed_calls`"
 
 [[param]]
+name = "network"
+type = "String"
+default = "\"bitcoin\".to_owned()"
+doc = "Which Bitcoin network the peers speak: bitcoin, testnet, signet or regtest. Selects the p2p magic bytes and the default peer port."
+
+[[param]]
 name = "peer_timeout"
 type = "u64"
 default = "30"

--- a/src/create_state.rs
+++ b/src/create_state.rs
@@ -65,7 +65,6 @@ pub fn create_state() -> Result<(State, SocketAddr), Error> {
         bitcoin::network::constants::Network::Testnet => 18333,
         bitcoin::network::constants::Network::Signet => 38333,
         bitcoin::network::constants::Network::Regtest => 18444,
-        _ => 8333,
     };
 
     let tor_only = config.tor_only;

--- a/src/create_state.rs
+++ b/src/create_state.rs
@@ -54,6 +54,20 @@ pub fn create_state() -> Result<(State, SocketAddr), Error> {
     })?;
     let rpc_client = RpcClient::new(auth, bitcoin_uri, &logger);
 
+    let network_name = config.network.clone();
+    let network: bitcoin::network::constants::Network = network_name.parse().map_err(|_| {
+        let msg = "network must be one of: bitcoin, testnet, signet, regtest";
+        slog::error!(logger, "{}", msg; "network" => &network_name);
+        anyhow::anyhow!("{} (got {:?})", msg, network_name)
+    })?;
+    let default_peer_port = match network {
+        bitcoin::network::constants::Network::Bitcoin => 8333,
+        bitcoin::network::constants::Network::Testnet => 18333,
+        bitcoin::network::constants::Network::Signet => 38333,
+        bitcoin::network::constants::Network::Regtest => 18444,
+        _ => 8333,
+    };
+
     let tor_only = config.tor_only;
     let tor = config.tor_proxy.map(|proxy| TorState {
         proxy,
@@ -137,6 +151,8 @@ pub fn create_state() -> Result<(State, SocketAddr), Error> {
             peers: RwLock::new(Arc::new(Peers::new())),
             max_peer_age: Duration::from_secs(config.max_peer_age),
             max_peer_concurrency: config.max_peer_concurrency,
+            magic: network.magic(),
+            default_peer_port,
         },
         bind_addr,
     ))

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -289,7 +289,14 @@ async fn fetch_block_from_peer<'a>(
         conn = tokio::task::spawn_blocking(move || {
             RawNetworkMessage {
                 magic,
-                payload: NetworkMessage::GetData(vec![Inventory::Block(hash)]),
+                // WitnessBlock, not Block: MSG_BLOCK makes a segwit-aware peer
+                // serve the *stripped* serialization, so the block that comes
+                // back is missing the marker/flag and every witness stack. It
+                // still passes both checks below — the merkle root commits to
+                // txids, which stripping does not change, and
+                // check_witness_commitment() returns true vacuously once no
+                // transaction carries a witness — so the loss is silent.
+                payload: NetworkMessage::GetData(vec![Inventory::WitnessBlock(hash)]),
             }
             .consensus_encode(&mut *conn)
             .map_err(Error::from)

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -53,6 +53,22 @@ fn version_message(magic: u32) -> RawNetworkMessage {
     }
 }
 
+/// `Block::check_witness_commitment` returns true for any block with no
+/// witnesses at all, which is exactly what a stripping peer returns.
+fn check_witnesses(block: &Block) -> bool {
+    const COMMITMENT_MAGIC: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+    let commits = block.txdata.first().map_or(false, |coinbase| {
+        coinbase.output.iter().any(|o| {
+            o.script_pubkey.len() >= 38 && o.script_pubkey.as_bytes()[..6] == COMMITMENT_MAGIC
+        })
+    });
+    let carries = block
+        .txdata
+        .iter()
+        .any(|tx| tx.input.iter().any(|i| !i.witness.is_empty()));
+    (carries || !commits) && block.check_witness_commitment()
+}
+
 #[derive(Debug)]
 pub struct Peers {
     fetched: Option<Instant>,
@@ -85,7 +101,9 @@ impl Peers {
                 .into_result()?
                 .into_iter()
                 .filter(|p| !p.inbound)
-                .filter(|p| p.servicesnames.contains("NETWORK"))
+                .filter(|p| {
+                    p.servicesnames.contains("NETWORK") && p.servicesnames.contains("WITNESS")
+                })
                 .map(|p| Peer::new(Arc::new(p.addr)))
                 .collect(),
             fetched: Some(Instant::now()),
@@ -151,11 +169,8 @@ impl Write for BitcoinPeerConnection {
     }
 }
 impl BitcoinPeerConnection {
-    /// Disable Nagle. `consensus_encode` writes a message to the socket in
-    /// several small pieces, and with Nagle on the kernel holds everything
-    /// after the first piece until the peer ACKs — which the peer's own
-    /// delayed-ACK timer defers by ~40ms. That turns every block fetch into a
-    /// fixed ~40ms stall regardless of how close the peer is.
+    /// `consensus_encode` writes a message in several small pieces, so Nagle
+    /// holds all but the first until the peer's delayed-ACK timer fires.
     fn set_nodelay(&self) -> std::io::Result<()> {
         match self {
             BitcoinPeerConnection::Direct(s) => s.set_nodelay(true),
@@ -304,13 +319,7 @@ async fn fetch_block_from_peer<'a>(
         conn = tokio::task::spawn_blocking(move || {
             RawNetworkMessage {
                 magic,
-                // WitnessBlock, not Block: MSG_BLOCK makes a segwit-aware peer
-                // serve the *stripped* serialization, so the block that comes
-                // back is missing the marker/flag and every witness stack. It
-                // still passes both checks below — the merkle root commits to
-                // txids, which stripping does not change, and
-                // check_witness_commitment() returns true vacuously once no
-                // transaction carries a witness — so the loss is silent.
+                // MSG_BLOCK gets the witness-stripped serialization.
                 payload: NetworkMessage::GetData(vec![Inventory::WitnessBlock(hash)]),
             }
             .consensus_encode(&mut *conn)
@@ -331,7 +340,7 @@ async fn fetch_block_from_peer<'a>(
                 NetworkMessage::Block(b) => {
                     let returned_hash = b.block_hash();
                     let merkle_check = b.check_merkle_root();
-                    let witness_check = b.check_witness_commitment();
+                    let witness_check = check_witnesses(&b);
                     return match (returned_hash == hash, merkle_check, witness_check) {
                         (true, true, true) => Ok((b, conn)),
                         (true, true, false) => {
@@ -453,4 +462,64 @@ pub async fn fetch_block(state: Arc<State>, hash: BlockHash) -> Result<Option<Bl
         ),
         None => None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_witnesses;
+    use bitcoin::blockdata::{
+        block::{Block, BlockHeader},
+        script::Script,
+        transaction::{OutPoint, Transaction, TxIn, TxOut},
+    };
+    use bitcoin::hashes::Hash;
+
+    fn block(commitment: bool, witness: bool) -> Block {
+        let mut commitment_spk = vec![0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+        commitment_spk.extend_from_slice(&[0x11; 32]);
+        Block {
+            header: BlockHeader {
+                version: 1,
+                prev_blockhash: bitcoin::BlockHash::all_zeros(),
+                merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+                time: 0,
+                bits: 0,
+                nonce: 0,
+            },
+            txdata: vec![Transaction {
+                version: 1,
+                lock_time: bitcoin::PackedLockTime(0),
+                input: vec![TxIn {
+                    previous_output: OutPoint::null(),
+                    script_sig: Script::from(vec![0x51, 0x51]),
+                    sequence: bitcoin::Sequence::MAX,
+                    witness: if witness {
+                        bitcoin::Witness::from_vec(vec![vec![0; 32]])
+                    } else {
+                        bitcoin::Witness::default()
+                    },
+                }],
+                output: vec![TxOut {
+                    value: 0,
+                    script_pubkey: Script::from(if commitment {
+                        commitment_spk
+                    } else {
+                        vec![0x51]
+                    }),
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn a_block_that_commits_to_witnesses_must_carry_them() {
+        let stripped = block(true, false);
+        assert!(stripped.check_witness_commitment());
+        assert!(!check_witnesses(&stripped));
+    }
+
+    #[test]
+    fn a_block_with_no_commitment_needs_no_witnesses() {
+        assert!(check_witnesses(&block(false, false)));
+    }
 }

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -10,7 +10,7 @@ use bitcoin::{
     consensus::{Decodable, Encodable},
     hash_types::BlockHash,
     network::{
-        constants::{Network::Bitcoin, ServiceFlags},
+        constants::ServiceFlags,
         message::{NetworkMessage, RawNetworkMessage},
         message_blockdata::Inventory,
         message_network::VersionMessage,
@@ -27,31 +27,30 @@ use crate::client::{
 use crate::rpc_methods::{GetBlock, GetBlockParams, GetPeerInfo, PeerAddressError};
 use crate::state::{State, TorState};
 
-type VersionMessageProducer = Box<dyn Fn() -> RawNetworkMessage + Send + Sync>;
-
-lazy_static::lazy_static! {
-    static ref VER_ACK: RawNetworkMessage = RawNetworkMessage {
-        magic: Bitcoin.magic(),
+fn ver_ack(magic: u32) -> RawNetworkMessage {
+    RawNetworkMessage {
+        magic,
         payload: NetworkMessage::Verack,
-    };
-    static ref VERSION_MESSAGE: VersionMessageProducer = Box::new(|| {
-        use std::time::SystemTime;
-        RawNetworkMessage {
-            magic: Bitcoin.magic(),
-            payload: NetworkMessage::Version(VersionMessage::new(
-                ServiceFlags::NONE,
-                SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs() as i64,
-                bitcoin::network::Address::new(&([127, 0, 0, 1], 8332).into(), ServiceFlags::NONE),
-                bitcoin::network::Address::new(&([127, 0, 0, 1], 8332).into(), ServiceFlags::NONE),
-                0,
-                format!("BTC RPC Proxy v{}", env!("CARGO_PKG_VERSION")),
-                0,
-            )),
-        }
-    });
+    }
+}
+
+fn version_message(magic: u32) -> RawNetworkMessage {
+    use std::time::SystemTime;
+    RawNetworkMessage {
+        magic,
+        payload: NetworkMessage::Version(VersionMessage::new(
+            ServiceFlags::NONE,
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+            bitcoin::network::Address::new(&([127, 0, 0, 1], 8332).into(), ServiceFlags::NONE),
+            bitcoin::network::Address::new(&([127, 0, 0, 1], 8332).into(), ServiceFlags::NONE),
+            0,
+            format!("BTC RPC Proxy v{}", env!("CARGO_PKG_VERSION")),
+            0,
+        )),
+    }
 }
 
 #[derive(Debug)]
@@ -154,7 +153,7 @@ impl Write for BitcoinPeerConnection {
 impl BitcoinPeerConnection {
     pub async fn connect(state: Arc<State>, mut addr: Arc<String>) -> Result<Self, Error> {
         if !addr.contains(":") {
-            addr = Arc::new(format!("{}:8333", &*addr));
+            addr = Arc::new(format!("{}:{}", &*addr, state.default_peer_port));
         }
         tokio::time::timeout(
             state.peer_timeout,
@@ -176,13 +175,13 @@ impl BitcoinPeerConnection {
                         _ => BitcoinPeerConnection::Direct(TcpStream::connect(&*addr)?),
                     }
                 };
-                VERSION_MESSAGE().consensus_encode(&mut stream)?;
+                version_message(state.magic).consensus_encode(&mut stream)?;
                 stream.flush()?;
                 let _ =
                     bitcoin::network::message::RawNetworkMessage::consensus_decode(&mut stream)?; // version
                 let _ =
                     bitcoin::network::message::RawNetworkMessage::consensus_decode(&mut stream)?; // verack
-                VER_ACK.consensus_encode(&mut stream)?;
+                ver_ack(state.magic).consensus_encode(&mut stream)?;
                 stream.flush()?;
 
                 Ok(stream)
@@ -285,10 +284,11 @@ async fn fetch_block_from_peer<'a>(
     hash: BlockHash,
     mut conn: RecyclableConnection,
 ) -> Result<(Block, RecyclableConnection), Error> {
+    let magic = state.magic;
     tokio::time::timeout(state.peer_timeout, async move {
         conn = tokio::task::spawn_blocking(move || {
             RawNetworkMessage {
-                magic: Bitcoin.magic(),
+                magic,
                 payload: NetworkMessage::GetData(vec![Inventory::Block(hash)]),
             }
             .consensus_encode(&mut *conn)
@@ -328,7 +328,7 @@ async fn fetch_block_from_peer<'a>(
                 NetworkMessage::Ping(p) => {
                     conn = tokio::task::spawn_blocking(move || {
                         RawNetworkMessage {
-                            magic: Bitcoin.magic(),
+                            magic,
                             payload: NetworkMessage::Pong(p),
                         }
                         .consensus_encode(&mut *conn)

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -151,6 +151,18 @@ impl Write for BitcoinPeerConnection {
     }
 }
 impl BitcoinPeerConnection {
+    /// Disable Nagle. `consensus_encode` writes a message to the socket in
+    /// several small pieces, and with Nagle on the kernel holds everything
+    /// after the first piece until the peer ACKs — which the peer's own
+    /// delayed-ACK timer defers by ~40ms. That turns every block fetch into a
+    /// fixed ~40ms stall regardless of how close the peer is.
+    fn set_nodelay(&self) -> std::io::Result<()> {
+        match self {
+            BitcoinPeerConnection::Direct(s) => s.set_nodelay(true),
+            BitcoinPeerConnection::Proxied(s) => s.get_ref().set_nodelay(true),
+        }
+    }
+
     pub async fn connect(state: Arc<State>, mut addr: Arc<String>) -> Result<Self, Error> {
         if !addr.contains(":") {
             addr = Arc::new(format!("{}:{}", &*addr, state.default_peer_port));
@@ -175,6 +187,9 @@ impl BitcoinPeerConnection {
                         _ => BitcoinPeerConnection::Direct(TcpStream::connect(&*addr)?),
                     }
                 };
+                if let Err(e) = stream.set_nodelay() {
+                    warn!(state.logger, "failed to set TCP_NODELAY"; "error" => %e);
+                }
                 version_message(state.magic).consensus_encode(&mut stream)?;
                 stream.flush()?;
                 let _ =

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,6 +27,13 @@ pub struct State {
     pub peers: RwLock<Arc<Peers>>,
     pub max_peer_age: Duration,
     pub max_peer_concurrency: Option<usize>,
+    /// p2p magic bytes for the network bitcoind is on. Every message the block
+    /// fetcher exchanges with a peer carries it, and a peer on another network
+    /// drops the connection rather than answering, so this has to track
+    /// bitcoind's actual chain rather than being assumed to be mainnet.
+    pub magic: u32,
+    /// Port to assume when `getpeerinfo` reports a peer address without one.
+    pub default_peer_port: u16,
 }
 impl State {
     pub fn leak(self) -> &'static Self {

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,10 +27,7 @@ pub struct State {
     pub peers: RwLock<Arc<Peers>>,
     pub max_peer_age: Duration,
     pub max_peer_concurrency: Option<usize>,
-    /// p2p magic bytes for the network bitcoind is on. Every message the block
-    /// fetcher exchanges with a peer carries it, and a peer on another network
-    /// drops the connection rather than answering, so this has to track
-    /// bitcoind's actual chain rather than being assumed to be mainnet.
+    /// A peer on another network drops the connection rather than answering.
     pub magic: u32,
     /// Port to assume when `getpeerinfo` reports a peer address without one.
     pub default_peer_port: u16,

--- a/src/users.rs
+++ b/src/users.rs
@@ -273,14 +273,8 @@ impl User {
                                 Ok((header, Some(block))) => Ok(Some(RpcResponse {
                                     id: req.id.clone(),
                                     result: {
-                                        let size = block.get_size();
-                                        let witness = block
-                                            .txdata
-                                            .iter()
-                                            .flat_map(|tx| tx.input.iter())
-                                            .flat_map(|input| input.witness.iter())
-                                            .map(|witness| witness.len())
-                                            .fold(0, |acc, x| acc + x);
+                                        let size = block.size();
+                                        let strippedsize = block.strippedsize();
                                         Some(serde_json::to_value(GetBlockResult {
                                             header: header.into_right().ok_or_else(|| {
                                                 anyhow::anyhow!(
@@ -288,12 +282,12 @@ impl User {
                                                 )
                                             })?,
                                             size,
-                                            strippedsize: if witness > 0 {
-                                                Some(size - witness)
+                                            strippedsize: if strippedsize != size {
+                                                Some(strippedsize)
                                             } else {
                                                 None
                                             },
-                                            weight: block.get_weight(),
+                                            weight: block.weight(),
                                             tx: block
                                                 .txdata
                                                 .into_iter()


### PR DESCRIPTION
Three changes to `fetch_blocks.rs`, found while building an electrs variant that indexes from a
pruned node through this proxy. Two are correctness/performance bugs that affect any pruned StartOS
node today; the third is what made them reproducible.

Happy to split these into separate PRs if you'd prefer — they're independent commits.

### 1. `getdata` asks for `MSG_BLOCK`, so fetched blocks are witness-stripped

`fetch_block_from_peer` requests `Inventory::Block(hash)`. A segwit-aware peer answers `MSG_BLOCK`
with the *stripped* serialization, so the block that comes back is missing the marker/flag and every
witness stack. `fetch_block_raw` then re-encodes that and returns it as the answer to `getblock`.

The loss is silent, because neither existing check can see it:

- `check_merkle_root()` passes — the merkle root commits to txids, which stripping does not change.
- `check_witness_commitment()` passes *vacuously* — it short-circuits to `true` once no transaction
  in the block carries a witness, which is exactly the state stripping produces.

Measured on regtest against an archival peer, block at height 100:

```
archival node : 504 hex chars
before        : 432 hex chars   <- missing marker/flag + coinbase witness
after         : 504 hex chars   <- byte-identical
```

Consumers get transactions with correct txids but the wrong serialization, which breaks anything
handing raw transactions to a wallet. Fixed by requesting `Inventory::WitnessBlock`.

Worth noting this is a peer *omission*, not a substitution — the requested hash comes from the local
node's validated header chain, so a peer still cannot forge content. But omission currently goes
undetected.

### 2. No `TCP_NODELAY`, so every fetch pays a Nagle stall

`consensus_encode` writes a p2p message to the socket in several small pieces. With Nagle on, the
kernel holds each piece after the first until the peer ACKs, and the peer's delayed-ACK timer defers
that by ~40 ms. Because *every* write in the encode path can stall, the penalty compounds with
message size rather than costing one flat delay.

Loopback (regtest, ~250-byte blocks), 100 sequential fetches:

| | blocks/s | median | p95 |
|---|---|---|---|
| before | 23.7 | 42.03 ms | 43.08 ms |
| after | 1692.0 | 0.58 ms | 0.68 ms |

The tight before-spread is the signature of a fixed timer rather than real work.

Real mainnet peers over clearnet, 5 fetches per height:

| height | block size | after | before |
|---|---|---|---|
| 200000 | 0.25 MB | 152.6 ms | 342.8 ms |
| 400000 | 0.95 MB | 159.5 ms | 482.6 ms |
| 600000 | 0.87 MB | 158.4 ms | 499.1 ms |
| 700000 | 1.28 MB | 164.6 ms | 589.5 ms |
| 800000 | 1.63 MB | 166.3 ms | 726.0 ms |
| 900000 | 1.92 MB | 172.7 ms | 931.7 ms |

With the option set, latency is flat in block size and throughput rises from 1.6 to 11.1 MB/s as
blocks grow. Without it, latency tracks size and throughput is pinned near 2 MB/s whatever the
block. So ~3.4x at the median and ~5.4x on present-day blocks, widening as blocks get bigger.

Over Tor the absolute cost is much higher (~2118 ms/block median against 162 ms on clearnet), so for
`onlynet=onion` nodes this matters more, not less.

### 3. Mainnet p2p magic is hardcoded, so the fetcher can't be exercised anywhere else

`Network::Bitcoin.magic()` appears at four sites, and `:8333` is assumed for any peer address
`getpeerinfo` reports without a port. A peer on another network drops the connection rather than
answering, so the pruned-block fetch path — the reason this proxy exists — could only ever run on
mainnet, and could not be tested without one.

Adds a `network` param (`bitcoin` | `testnet` | `signet` | `regtest`, default `bitcoin`, so existing
deployments are unaffected) and carries the resolved magic and default port on `State`.

This is what made 1 and 2 reproducible: with it, a two-node regtest setup (archival peer + pruned
node + proxy) demonstrates both, and the fix for each, deterministically.

## How this was tested

- Two-node regtest harness: archival node A, pruned node B connected outbound to A, proxy in front
  of B's RPC. B pruned to a known `pruneheight`; blocks below it are unavailable locally and must
  come from A via the peer fetcher.
- Mainnet figures come from a standalone client that replicates `fetch_block_from_peer` — same
  handshake (`services=NONE`, `relay=0`), same one-block-per-`getdata`, same validation — against
  peers found via DNS seeds, and via `addrv2`-harvested onion peers for the Tor numbers.
- Harness and benchmarks: https://github.com/paulscode/pruned-electrs (`spikes/`)

No behaviour change for existing deployments: `network` defaults to `bitcoin`, and the other two
commits only affect what is asked of a peer and how the socket is configured.
