### PR TITLE
Derive the p2p network from bitcoind instead of configuring it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "btc-rpc-proxy"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 description = "Finer-grained permission management for bitcoind."
 edition = "2018"
 name = "btc-rpc-proxy"
-version = "0.6.0"
+version = "0.7.0"
 
 [lib]
 name = "btc_rpc_proxy"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Only peers advertising `NETWORK` and `WITNESS` are asked, since a fetched block 
 
 Peers are reached over clearnet, or through `tor_proxy` for `.onion` addresses. Reaching `.b32.i2p` peers additionally needs `i2p_proxy` pointed at an I2P SOCKSv5 proxy (i2pd's `socksproxy`, for instance); without one those peers cannot be used, as Tor cannot resolve them.
 
-`network` must match the chain bitcoind is on — it selects the p2p magic bytes and the default peer port, and a peer on another network drops the connection rather than answering, so getting it wrong makes every pruned block unfetchable. Accepted values are `bitcoin` (the default), `testnet`, `signet` and `regtest`. These are **not** the names Core uses in `chain=`: a node started with `chain=main` needs `network = "bitcoin"` here, and `chain=test` needs `network = "testnet"`. `testnet4` is not supported.
+Which network the peers speak is not configured. The p2p magic bytes and the default peer port are taken from bitcoind's own `getblockchaininfo` the first time a block has to be fetched, and cached for the life of the process — a node cannot change chain without a restart, and the proxy restarts with it. `main`, `test`, `testnet4`, `signet` and `regtest` are all understood, and a signet's magic is computed from the challenge that node reports, so custom signets work too.
 
 ## Usage
 

--- a/btc_rpc_proxy.toml
+++ b/btc_rpc_proxy.toml
@@ -1,8 +1,6 @@
 bitcoind_user = "bitcoinrpc"
 bitcoind_password = "taxation is theft"
 bind_address = "127.0.0.1"
-# Must match bitcoind's chain: bitcoin (default), testnet, signet or regtest.
-# network = "bitcoin"
 
 [user.public]
 password = "public"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -79,12 +79,6 @@ argument = false
 doc = "Map of user names to user configs. Each user must specify `password` field and an array of allowed calls named `allowed_calls`"
 
 [[param]]
-name = "network"
-type = "String"
-default = "\"bitcoin\".to_owned()"
-doc = "Which Bitcoin network the peers speak: bitcoin, testnet, signet or regtest. Selects the p2p magic bytes and the default peer port."
-
-[[param]]
 name = "peer_timeout"
 type = "u64"
 default = "30"

--- a/src/create_state.rs
+++ b/src/create_state.rs
@@ -6,7 +6,7 @@ use btc_rpc_proxy::users::Password;
 use btc_rpc_proxy::{AuthSource, Peers, RpcClient, State, TorState};
 use slog::Drain;
 use systemd_socket::SocketAddr;
-use tokio::sync::RwLock;
+use tokio::sync::{OnceCell, RwLock};
 
 mod config {
     include!(concat!(env!("OUT_DIR"), "/configure_me_config.rs"));
@@ -53,19 +53,6 @@ pub fn create_state() -> Result<(State, SocketAddr), Error> {
         new_error
     })?;
     let rpc_client = RpcClient::new(auth, bitcoin_uri, &logger);
-
-    let network_name = config.network.clone();
-    let network: bitcoin::network::constants::Network = network_name.parse().map_err(|_| {
-        let msg = "network must be one of: bitcoin, testnet, signet, regtest";
-        slog::error!(logger, "{}", msg; "network" => &network_name);
-        anyhow::anyhow!("{} (got {:?})", msg, network_name)
-    })?;
-    let default_peer_port = match network {
-        bitcoin::network::constants::Network::Bitcoin => 8333,
-        bitcoin::network::constants::Network::Testnet => 18333,
-        bitcoin::network::constants::Network::Signet => 38333,
-        bitcoin::network::constants::Network::Regtest => 18444,
-    };
 
     let tor_only = config.tor_only;
     let tor = config.tor_proxy.map(|proxy| TorState {
@@ -150,8 +137,7 @@ pub fn create_state() -> Result<(State, SocketAddr), Error> {
             peers: RwLock::new(Arc::new(Peers::new())),
             max_peer_age: Duration::from_secs(config.max_peer_age),
             max_peer_concurrency: config.max_peer_concurrency,
-            magic: network.magic(),
-            default_peer_port,
+            network: OnceCell::new(),
         },
         bind_addr,
     ))

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -179,8 +179,9 @@ impl BitcoinPeerConnection {
     }
 
     pub async fn connect(state: Arc<State>, mut addr: Arc<String>) -> Result<Self, Error> {
+        let network = state.network_params().await?;
         if !addr.contains(":") {
-            addr = Arc::new(format!("{}:{}", &*addr, state.default_peer_port));
+            addr = Arc::new(format!("{}:{}", &*addr, network.default_peer_port));
         }
         tokio::time::timeout(
             state.peer_timeout,
@@ -205,13 +206,13 @@ impl BitcoinPeerConnection {
                 if let Err(e) = stream.set_nodelay() {
                     warn!(state.logger, "failed to set TCP_NODELAY"; "error" => %e);
                 }
-                version_message(state.magic).consensus_encode(&mut stream)?;
+                version_message(network.magic).consensus_encode(&mut stream)?;
                 stream.flush()?;
                 let _ =
                     bitcoin::network::message::RawNetworkMessage::consensus_decode(&mut stream)?; // version
                 let _ =
                     bitcoin::network::message::RawNetworkMessage::consensus_decode(&mut stream)?; // verack
-                ver_ack(state.magic).consensus_encode(&mut stream)?;
+                ver_ack(network.magic).consensus_encode(&mut stream)?;
                 stream.flush()?;
 
                 Ok(stream)
@@ -314,7 +315,7 @@ async fn fetch_block_from_peer<'a>(
     hash: BlockHash,
     mut conn: RecyclableConnection,
 ) -> Result<(Block, RecyclableConnection), Error> {
-    let magic = state.magic;
+    let magic = state.network_params().await?.magic;
     tokio::time::timeout(state.peer_timeout, async move {
         conn = tokio::task::spawn_blocking(move || {
             RawNetworkMessage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use hyper::{
 pub use crate::client::{AuthSource, RpcClient};
 pub use crate::fetch_blocks::Peers;
 use crate::proxy::proxy_request;
-pub use crate::state::{State, TorState};
+pub use crate::state::{NetworkError, NetworkParams, State, TorState};
 pub use crate::users::{User, Users};
 
 pub async fn main(state: Arc<State>, bind_addr: systemd_socket::SocketAddr) -> Result<(), Error> {

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -1,5 +1,5 @@
 use bitcoin::hash_types::BlockHash;
-use linear_map::{set::LinearSet, LinearMap};
+use linear_map::set::LinearSet;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::client::RpcMethod;
@@ -183,93 +183,19 @@ impl<'de> Deserialize<'de> for GetPeerInfo {
 #[derive(Debug)]
 pub struct GetBlockchainInfo;
 
-// https://docs.rs/bitcoincore-rpc-json/0.12.0/src/bitcoincore_rpc_json/lib.rs.html#551-557
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Bip9SoftforkStatus {
-    Defined,
-    Started,
-    LockedIn,
-    Active,
-    Failed,
-}
-
-// https://docs.rs/bitcoincore-rpc-json/0.12.0/src/bitcoincore_rpc_json/lib.rs.html#560-566
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct Bip9SoftforkStatistics {
-    pub period: u32,
-    pub threshold: u32,
-    pub elapsed: u32,
-    pub count: u32,
-    pub possible: bool,
-}
-
-// https://docs.rs/bitcoincore-rpc-json/0.12.0/src/bitcoincore_rpc_json/lib.rs.html#569-577
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct Bip9SoftforkInfo {
-    pub status: Bip9SoftforkStatus,
-    pub bit: Option<u8>,
-    // Can be -1 for 0.18.x inactive ones.
-    pub start_time: i64,
-    pub timeout: u64,
-    pub since: u32,
-    pub statistics: Option<Bip9SoftforkStatistics>,
-}
-
-// https://docs.rs/bitcoincore-rpc-json/0.12.0/src/bitcoincore_rpc_json/lib.rs.html#581-584
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SoftforkType {
-    Buried,
-    Bip9,
-}
-
-// https://docs.rs/bitcoincore-rpc-json/0.12.0/src/bitcoincore_rpc_json/lib.rs.html#588-594
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct Softfork {
-    #[serde(rename = "type")]
-    pub type_: SoftforkType,
-    pub bip9: Option<Bip9SoftforkInfo>,
-    pub height: Option<u32>,
-    pub active: bool,
-}
-
-// https://docs.rs/bitcoincore-rpc-json/0.12.0/src/bitcoincore_rpc_json/lib.rs.html#700-740
+/// Only the fields the proxy reads, for the same reason as `PeerInfo`: naming a
+/// key here makes it mandatory, and this response has changed shape under it
+/// twice. `softforks` moved to `getdeploymentinfo` in Core 23.0 and was dropped
+/// outright in 24.0.1, and `warnings` became an array in 28.0 — both used to be
+/// named here, so as written this struct could not parse a current node at all.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BlockchainInfo {
-    /// Current network name as defined in BIP70 (main, test, regtest)
+    /// The chain bitcoind is on, spelled as `-chain=` takes it: `main`, `test`,
+    /// `testnet4`, `signet` or `regtest`.
     pub chain: String,
-    /// The current number of blocks processed in the server
-    pub blocks: u64,
-    /// The current number of headers we have validated
-    pub headers: u64,
-    /// The hash of the currently best block
-    pub bestblockhash: bitcoin::BlockHash,
-    /// The current difficulty
-    pub difficulty: f64,
-    /// Median time for the current best block
-    pub mediantime: u64,
-    /// Estimate of verification progress [0..1]
-    pub verificationprogress: f64,
-    /// Estimate of whether this node is in Initial Block Download mode
-    pub initialblockdownload: bool,
-    /// Total amount of work in active chain, in hexadecimal
-    pub chainwork: HexBytes,
-    /// The estimated size of the block and undo files on disk
-    pub size_on_disk: u64,
-    /// If the blocks are subject to pruning
-    pub pruned: bool,
-    /// Lowest-height complete block stored (only present if pruning is enabled)
-    pub pruneheight: Option<u64>,
-    /// Whether automatic pruning is enabled (only present if pruning is enabled)
-    pub automatic_pruning: Option<bool>,
-    /// The target size used by pruning (only present if automatic pruning is enabled)
-    pub prune_target_size: Option<u64>,
-    /// Status of softforks in progress
-    #[serde(default)]
-    pub softforks: LinearMap<String, Softfork>,
-    /// Any network and blockchain warnings.
-    pub warnings: String,
+    /// The block challenge, emitted only on signet. Signet derives its p2p
+    /// magic from this, so a custom signet's differs from the default one's.
+    pub signet_challenge: Option<HexBytes>,
 }
 
 impl RpcMethod for GetBlockchainInfo {
@@ -300,7 +226,7 @@ impl<'de> Deserialize<'de> for GetBlockchainInfo {
 
 #[cfg(test)]
 mod tests {
-    use super::PeerInfo;
+    use super::{BlockchainInfo, PeerInfo};
 
     /// One `getpeerinfo` entry exactly as Bitcoin Core v31.1 emits it for an
     /// outbound clearnet peer. Core 31.0 put `startingheight` behind
@@ -365,5 +291,97 @@ mod tests {
             .replace(r#""pingtime": 0.041,"#, "")
             .replace(r#""session_id": "abc""#, r#""session_id": """#);
         serde_json::from_str::<PeerInfo>(&stripped).expect("failed to parse");
+    }
+
+    /// `getblockchaininfo` off a Knots 29.4.1 node started with `-chain=signet`,
+    /// verbatim. Note `warnings` as an array, which Core 28.0 changed it to, and
+    /// no `softforks`, which Core 24.0.1 dropped.
+    const CORE_29_SIGNET: &str = r#"{
+      "chain": "signet",
+      "blocks": 0,
+      "headers": 0,
+      "bestblockhash": "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
+      "bits": "1e0377ae",
+      "target": "00000377ae000000000000000000000000000000000000000000000000000000",
+      "difficulty": 0.001126515290698186,
+      "time": 1598918400,
+      "mediantime": 1598918400,
+      "verificationprogress": 1.509425027448838e-08,
+      "initialblockdownload": true,
+      "chainwork": "000000000000000000000000000000000000000000000000000000000049d414",
+      "size_on_disk": 293,
+      "pruned": false,
+      "signet_challenge": "512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae",
+      "warnings": [
+      ]
+    }"#;
+
+    #[test]
+    fn parses_core_29_signet() {
+        let info: BlockchainInfo = serde_json::from_str(CORE_29_SIGNET).expect("failed to parse");
+        assert_eq!(info.chain, "signet");
+        assert_eq!(
+            info.signet_challenge.as_ref().map(|c| c.len()),
+            Some(71),
+            "the challenge the signet magic is derived from"
+        );
+    }
+
+    /// Same node, `-chain=testnet4`. Every chain but signet omits the
+    /// challenge, and a missing key may not be an error.
+    #[test]
+    fn parses_core_29_testnet4() {
+        let info: BlockchainInfo = serde_json::from_str(
+            r#"{
+              "chain": "testnet4",
+              "blocks": 0,
+              "headers": 0,
+              "bestblockhash": "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043",
+              "bits": "1d00ffff",
+              "target": "00000000ffff0000000000000000000000000000000000000000000000000000",
+              "difficulty": 1,
+              "time": 1714777860,
+              "mediantime": 1714777860,
+              "verificationprogress": 1.528233146510922e-08,
+              "initialblockdownload": true,
+              "chainwork": "0000000000000000000000000000000000000000000000000000000100010001",
+              "size_on_disk": 269,
+              "pruned": false,
+              "warnings": [
+              ]
+            }"#,
+        )
+        .expect("failed to parse");
+        assert_eq!(info.chain, "testnet4");
+        assert!(info.signet_challenge.is_none());
+    }
+
+    /// The single-string `warnings` of Core 27 and earlier, and the `softforks`
+    /// object dropped in 24.0.1, both still parse — nothing here names either.
+    /// A proxy may be pointed at a node older than the one above.
+    #[test]
+    fn parses_older_node_shape() {
+        let info: BlockchainInfo = serde_json::from_str(
+            r#"{
+              "chain": "main",
+              "blocks": 800000,
+              "headers": 800000,
+              "bestblockhash": "00000000000000000002a7c4c1e48d76c5a37902165a270156b7a8d72728a054",
+              "difficulty": 53911173001054.59,
+              "mediantime": 1690168629,
+              "verificationprogress": 0.9999,
+              "initialblockdownload": false,
+              "chainwork": "00000000000000000000000000000000000000004fd66f4dd0d1a9b8a4b6a7ad",
+              "size_on_disk": 500000000,
+              "pruned": true,
+              "pruneheight": 799000,
+              "automatic_pruning": true,
+              "prune_target_size": 550000000,
+              "softforks": { "bip34": { "type": "buried", "active": true, "height": 227931 } },
+              "warnings": ""
+            }"#,
+        )
+        .expect("failed to parse");
+        assert_eq!(info.chain, "main");
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,17 +3,90 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Error;
+use bitcoin::consensus::encode::{Encodable, VarInt};
+use bitcoin::hashes::{sha256d, Hash};
 use slog::Logger;
-use tokio::sync::RwLock;
+use tokio::sync::{OnceCell, RwLock};
 
-use crate::client::RpcClient;
+use crate::client::{RpcClient, RpcRequest};
 use crate::fetch_blocks::{PeerHandle, Peers};
+use crate::rpc_methods::{BlockchainInfo, GetBlockchainInfo};
 use crate::users::Users;
 
 #[derive(Debug)]
 pub struct TorState {
     pub proxy: SocketAddr,
     pub only: bool,
+}
+
+/// What the p2p handshake needs to know about the chain bitcoind is on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkParams {
+    /// The four bytes every p2p message starts with, read as a little-endian
+    /// `u32` the way `RawNetworkMessage` wants them: mainnet's `f9 be b4 d9`
+    /// on the wire is `0xD9B4BEF9` here. A peer on another network drops the
+    /// connection rather than answering.
+    pub magic: u32,
+    /// Port to assume when `getpeerinfo` reports a peer address without one.
+    pub default_peer_port: u16,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum NetworkError {
+    #[error("bitcoind reports an unrecognized chain: {0:?}")]
+    UnknownChain(String),
+    #[error("bitcoind reports chain \"signet\" but no signet_challenge, which its p2p magic is derived from")]
+    MissingSignetChallenge,
+}
+
+impl NetworkParams {
+    /// The chain names are `ChainTypeToString` in Core's `util/chaintype.cpp`,
+    /// which is what `getblockchaininfo` reports and what `-chain=` accepts.
+    /// The magic and port for each are `kernel/chainparams.cpp`.
+    pub fn from_blockchain_info(info: &BlockchainInfo) -> Result<Self, NetworkError> {
+        Ok(match &*info.chain {
+            "main" => NetworkParams {
+                magic: 0xD9B4BEF9,
+                default_peer_port: 8333,
+            },
+            "test" => NetworkParams {
+                magic: 0x0709110B,
+                default_peer_port: 18333,
+            },
+            "testnet4" => NetworkParams {
+                magic: 0x283F161C,
+                default_peer_port: 48333,
+            },
+            "signet" => NetworkParams {
+                magic: signet_magic(
+                    info.signet_challenge
+                        .as_ref()
+                        .ok_or(NetworkError::MissingSignetChallenge)?,
+                ),
+                default_peer_port: 38333,
+            },
+            "regtest" => NetworkParams {
+                magic: 0xDAB5BFFA,
+                default_peer_port: 18444,
+            },
+            other => return Err(NetworkError::UnknownChain(other.to_owned())),
+        })
+    }
+}
+
+/// Signet is the one network with no fixed magic: it is the first four bytes of
+/// the double SHA256 of the block challenge, so every custom signet has its
+/// own. This mirrors `CSigNetParams`, length prefix included — the challenge is
+/// hashed as a serialized byte vector, not bare.
+fn signet_magic(challenge: &[u8]) -> u32 {
+    let mut buf = Vec::with_capacity(challenge.len() + 9);
+    VarInt(challenge.len() as u64)
+        .consensus_encode(&mut buf)
+        .expect("writing to a Vec cannot fail");
+    buf.extend_from_slice(challenge);
+    let mut magic = [0; 4];
+    magic.copy_from_slice(&sha256d::Hash::hash(&buf).into_inner()[..4]);
+    u32::from_le_bytes(magic)
 }
 
 #[derive(Debug)]
@@ -27,10 +100,9 @@ pub struct State {
     pub peers: RwLock<Arc<Peers>>,
     pub max_peer_age: Duration,
     pub max_peer_concurrency: Option<usize>,
-    /// A peer on another network drops the connection rather than answering.
-    pub magic: u32,
-    /// Port to assume when `getpeerinfo` reports a peer address without one.
-    pub default_peer_port: u16,
+    /// Filled in from bitcoind the first time a block is fetched from a peer.
+    /// A node cannot change chain without a restart, and this restarts with it.
+    pub network: OnceCell<NetworkParams>,
 }
 impl State {
     pub fn leak(self) -> &'static Self {
@@ -38,6 +110,38 @@ impl State {
     }
     pub fn arc(self) -> Arc<Self> {
         Arc::new(self)
+    }
+    /// The magic and default peer port for bitcoind's chain, asked for once and
+    /// cached.
+    ///
+    /// Deliberately lazy, and it costs nothing to be. The only caller is the
+    /// peer-fetch path, which `fetch_block_raw` reaches only after `getblock`
+    /// has come back pruned and `getpeerinfo` has returned a peer list. Both go
+    /// to this same client, so by the time this runs bitcoind has answered
+    /// twice: it can add no startup requirement, and a proxy that never fetches
+    /// never asks at all. Concurrent first fetches queue on the `OnceCell`
+    /// rather than each issuing the call.
+    pub async fn network_params(&self) -> Result<NetworkParams, Error> {
+        self.network
+            .get_or_try_init(|| async {
+                let info = self
+                    .rpc_client
+                    .call(&RpcRequest {
+                        id: None,
+                        method: GetBlockchainInfo,
+                        params: [],
+                    })
+                    .await?
+                    .into_result()?;
+                let params = NetworkParams::from_blockchain_info(&info)?;
+                info!(self.logger, "took p2p parameters from bitcoind";
+                    "chain" => info.chain.as_str(),
+                    "magic" => format!("{:08x}", params.magic),
+                    "default_peer_port" => params.default_peer_port);
+                Ok::<_, Error>(params)
+            })
+            .await
+            .copied()
     }
     pub async fn get_peers(self: Arc<Self>) -> Result<Vec<PeerHandle>, Error> {
         let mut peers = self.peers.read().await.clone();
@@ -60,5 +164,83 @@ impl State {
             }
         }
         Ok(peers.handles())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NetworkError, NetworkParams};
+    use crate::rpc_methods::BlockchainInfo;
+
+    fn params(json: &str) -> Result<NetworkParams, NetworkError> {
+        let info: BlockchainInfo = serde_json::from_str(json).expect("failed to parse");
+        NetworkParams::from_blockchain_info(&info)
+    }
+
+    /// The four bytes in wire order, which is how `pchMessageStart` reads in
+    /// Core's `kernel/chainparams.cpp`.
+    fn wire(magic: u32) -> String {
+        hex::encode(magic.to_le_bytes())
+    }
+
+    #[test]
+    fn every_chain_gets_its_own_magic_and_port() {
+        for (chain, magic, port) in [
+            ("main", "f9beb4d9", 8333u16),
+            ("test", "0b110907", 18333),
+            ("testnet4", "1c163f28", 48333),
+            ("regtest", "fabfb5da", 18444),
+        ] {
+            let got = params(&format!(r#"{{"chain":"{}"}}"#, chain)).expect(chain);
+            assert_eq!(wire(got.magic), magic, "magic for {}", chain);
+            assert_eq!(got.default_peer_port, port, "port for {}", chain);
+        }
+    }
+
+    /// The default signet challenge, verbatim from a Knots 29.4.1 node started
+    /// with `-chain=signet`. Hashing it has to land on the signet magic that
+    /// rust-bitcoin carries as a hardcoded constant, which is what makes this a
+    /// check of the derivation rather than of itself. Core does not carry it:
+    /// it computes it the same way this does.
+    const DEFAULT_SIGNET_CHALLENGE: &str = "512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae";
+
+    #[test]
+    fn the_default_signet_challenge_hashes_to_the_known_signet_magic() {
+        let got = params(&format!(
+            r#"{{"chain":"signet","signet_challenge":"{}"}}"#,
+            DEFAULT_SIGNET_CHALLENGE
+        ))
+        .expect("signet");
+        assert_eq!(got.magic, 0x40CF030A);
+        assert_eq!(wire(got.magic), "0a03cf40");
+        assert_eq!(got.default_peer_port, 38333);
+    }
+
+    /// A custom signet is a different network on the wire. A configured network
+    /// name could not say which one; the challenge can.
+    #[test]
+    fn a_custom_signet_gets_a_different_magic() {
+        let got = params(r#"{"chain":"signet","signet_challenge":"51"}"#).expect("signet");
+        assert_ne!(got.magic, 0x40CF030A);
+        assert_eq!(got.default_peer_port, 38333);
+    }
+
+    #[test]
+    fn signet_without_a_challenge_is_an_error() {
+        assert!(matches!(
+            params(r#"{"chain":"signet"}"#),
+            Err(NetworkError::MissingSignetChallenge)
+        ));
+    }
+
+    /// `bitcoin` was the accepted spelling while this was configured. It is not
+    /// what bitcoind calls mainnet, and guessing at it is the whole point of
+    /// asking instead.
+    #[test]
+    fn an_unrecognized_chain_is_an_error() {
+        assert!(matches!(
+            params(r#"{"chain":"bitcoin"}"#),
+            Err(NetworkError::UnknownChain(chain)) if chain == "bitcoin"
+        ));
     }
 }


### PR DESCRIPTION
Follow-up to #29. That PR added a `network` option so the peer fetcher could run on something other than mainnet. This one removes it again and asks bitcoind instead.

## Why

`network` is a knob whose only failure mode is silent. Set it wrong and every peer drops the connection at the handshake rather than answering, which the fetch path cannot distinguish from an unresponsive peer, so a pruned block just never arrives and nothing in the log says why.

The names also do not line up with anything the operator already typed. A node started with `chain=main` needs `network = "bitcoin"` here, and testnet4 cannot be expressed at all, because rust-bitcoin 0.29's `Network` enum has no variant for it.

bitcoind already knows the answer. `getblockchaininfo` reports the chain, so the chain name now maps straight to a magic and a default port, which skips the `Network` enum that was the reason testnet4 was out of reach.

## The startup dependency this was held back for

This was left out of #29 on the grounds that it would make the proxy depend on bitcoind's RPC at startup. Looking at where the call actually lands, I do not think it does, and I should have laid that out at the time.

`network_params` sits behind a `OnceCell` whose only caller is the peer-fetch path. `fetch_block_raw` reaches that path only after `getblock` has come back pruned and `getpeerinfo` has returned a peer list, and both of those go to this same RPC client. By the time the network is resolved, bitcoind has already answered twice, so this cannot add a startup requirement that was not there. A proxy that never fetches never asks at all, one that does ask asks once and caches for the life of the process, and concurrent first fetches queue on the `OnceCell` rather than each issuing the call.

Caching for the process lifetime is correct because a node cannot change chain without restarting, and the proxy restarts with it.

## What this reaches that the option could not

**testnet4.** `getblockchaininfo` reports `testnet4`, magic `1c163f28` on the wire, default port 48333.

**Custom signets.** Signet has no fixed magic: it is the first four bytes of the double SHA256 of the serialized block challenge, so `network = "signet"` could only ever mean the default signet. The challenge comes back in the same `getblockchaininfo` response, so the magic is computed from it.

## Breaking change: `network` is gone

Worth being precise about, for anyone who set it in v0.6.0.

* In a **config file**, `network = "..."` is now ignored. configure_me ignores unknown keys, so a stale config still starts and the proxy derives the network itself. Nothing to do beyond deleting the line.
* On the **command line**, `--network <value>` is rejected: `Error: An unknown argument '--network' was specified.`, exit 1. That one has to be removed.

There is no environment variable form (the generated `merge_env` is empty), so that is the whole surface. The option only ever shipped in v0.6.0, so anything on v0.5.1 or earlier is unaffected.

## First commit: `BlockchainInfo` could not parse a current node

`GetBlockchainInfo` was already in the tree but had never been called, and as written it could not be. `getblockchaininfo` has changed shape twice under fields that struct names:

* `softforks` moved to `getdeploymentinfo` in Core 23.0 and was dropped outright in 24.0.1. `#[serde(default)]` covered that one.
* `warnings` became an array in Core 28.0. That one is fatal. Against a Knots 29.4.1 node the response fails with `invalid type: sequence, expected a string`.

So the first commit narrows it to the two fields the proxy reads and lets serde ignore the rest. That is the reasoning already written above `PeerInfo`, and the same failure that took the peer list down when `startingheight` moved behind `-deprecatedrpc`. The softfork types existed only to describe that field and go with it.

## Verification

All local. The only workflow here triggers on `v*` tags, so CI will not run on this.

**Unit, 19 pass**, and the first commit is green on its own at 14 for bisecting. Each chain's magic is asserted in wire-byte order against `kernel/chainparams.cpp`. The default signet challenge, captured verbatim from a Knots 29.4.1 node, hashes to `0x40CF030A`, which rust-bitcoin carries as a hardcoded constant, so the derivation is checked against something other than itself. A custom signet lands somewhere else. Both error paths are covered. Three more tests parse real `getblockchaininfo` output from that node on signet and on testnet4, plus a synthetic older response carrying the single-string `warnings` of Core 27 and the `softforks` object 24.0.1 dropped, since a proxy may be pointed at a node older than the one those were captured from.

**End to end on regtest.** Two nodes, archival A feeding pruned B, proxy in front of B with no `network` key in its config. Five blocks below B's prune height, which B itself answers with a prune error, came back through the proxy and hashed to the hash requested:

```
INFO took p2p parameters from bitcoind, default_peer_port: 18444, magic: dab5bffa, chain: regtest
```

The same run with `network = "regtest"` still in the config file also worked, which is where the stale-config claim above comes from.

**testnet4 magic on the wire.** Three live testnet4 nodes completed a version exchange against `1c163f28`, so that constant is confirmed against third parties and not only against chainparams.cpp.

`cargo clippy --all-targets` reports nothing new in the touched files, and `cargo fmt --check` shows no diff in them (build.rs, proxy.rs and util.rs already differ on master).
