### PR TITLE
Serve getrawtransaction for a pruned block when a blockhash is given

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "btc-rpc-proxy"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 description = "Finer-grained permission management for bitcoind."
 edition = "2018"
 name = "btc-rpc-proxy"
-version = "0.7.0"
+version = "0.8.0"
 
 [lib]
 name = "btc_rpc_proxy"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Two options tune what a fetch costs:
 
 Only peers advertising `NETWORK` and `WITNESS` are asked, since a fetched block is served with its witness data and checked against the witness commitment in its own coinbase.
 
+The same fetch answers `getrawtransaction` when a blockhash is given, which is what an Electrum server needs to serve a verbose transaction lookup against a pruned node.
+
 A block fetched from a peer is kept in memory so the next request for it does not go back to the network. Only peer-fetched blocks are cached, since anything bitcoind still holds is cheap to ask for again. `block_cache_size_mib` bounds it, 64 by default, and 0 turns it off. The bound matters: an unbounded cache would give back the disk saving that motivates running pruned in the first place.
 
 Peers are reached over clearnet, or through `tor_proxy` for `.onion` addresses. Reaching `.b32.i2p` peers additionally needs `i2p_proxy` pointed at an I2P SOCKSv5 proxy (i2pd's `socksproxy`, for instance); without one those peers cannot be used, as Tor cannot resolve them.
@@ -64,7 +66,8 @@ Especially in case of packaged software.
 ## Limitations
 
 * It uses `serde_json`, which allocates during deserialization (`Value`). Expect a bit lower performance than without proxy.
-* Only `getblock` verbosity 0 and 1 are intercepted. Verbosity 2 is forwarded to your node, so it still fails for a pruned block — and could not be answered faithfully anyway, since the per-input `fee` fields need undo data a pruned node no longer has.
+* `getblock` is intercepted at verbosity 0 and 1. Verbosity 2 is forwarded to your node, so it still fails for a pruned block — and could not be answered faithfully anyway, since the per-input `fee` fields need undo data a pruned node no longer has.
+* `getrawtransaction` is intercepted only when a blockhash is given. Without one Core needs `txindex` and the proxy has no txid index to substitute for it; verbosity 2 needs the same undo data as above. Both are forwarded.
 * Logging can't be configured yet.
 * No support for changing UID.
 * No support for Unix sockets.

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -423,9 +423,6 @@ mod tests {
         assert!(info.signet_challenge.is_none());
     }
 
-    /// The single-string `warnings` of Core 27 and earlier, and the `softforks`
-    /// object dropped in 24.0.1, both still parse — nothing here names either.
-    /// A proxy may be pointed at a node older than the one above.
     /// Core reports -1 confirmations for a header that is not on the main
     /// chain. This was `u32`, so a reorged-out block surfaced as "can't be
     /// parsed as json" from whichever call happened to ask.
@@ -453,6 +450,9 @@ mod tests {
         assert_eq!(header.confirmations, -1);
     }
 
+    /// The single-string `warnings` of Core 27 and earlier, and the `softforks`
+    /// object dropped in 24.0.1, both still parse — nothing here names either.
+    /// A proxy may be pointed at a node older than the one above.
     #[test]
     fn parses_older_node_shape() {
         let info: BlockchainInfo = serde_json::from_str(

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -1,6 +1,7 @@
-use bitcoin::hash_types::BlockHash;
+use bitcoin::hash_types::{BlockHash, Txid};
 use linear_map::set::LinearSet;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
 
 use crate::client::RpcMethod;
 use crate::util::{Either, HexBytes};
@@ -79,7 +80,12 @@ impl<'de> Deserialize<'de> for GetBlockHeader {
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockHeaderResult {
     pub hash: bitcoin::BlockHash,
-    pub confirmations: u32,
+    /// Signed, because Core returns **-1** for a header that is not on the main
+    /// chain. As `u32` this failed to deserialize and surfaced as "can't be
+    /// parsed as json", which is a confusing way to learn a block was reorged
+    /// out. Both callers of this struct go through `getblockheader` with
+    /// verbose set, so both could hit it.
+    pub confirmations: i32,
     pub height: usize,
     pub version: i32,
     pub version_hex: Option<HexBytes>,
@@ -177,6 +183,67 @@ impl<'de> Deserialize<'de> for GetPeerInfo {
                 &Self.as_str(),
             ))
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct GetRawTransaction;
+
+/// `getrawtransaction "txid" ( verbose "blockhash" )`.
+///
+/// Only the three-argument form is intercepted. Without a blockhash Core needs
+/// `txindex`, and the proxy has no txid index of its own to substitute for one.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetRawTransactionParams(
+    pub Txid,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Option<Value>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub Option<BlockHash>,
+);
+impl RpcMethod for GetRawTransaction {
+    type Params = GetRawTransactionParams;
+    type Response = Value;
+    fn as_str(&self) -> &'static str {
+        "getrawtransaction"
+    }
+}
+impl Serialize for GetRawTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_str().serialize(serializer)
+    }
+}
+
+#[derive(Debug)]
+pub struct DecodeRawTransaction;
+
+/// The rendering half of a verbose `getrawtransaction`, done by Core rather
+/// than reimplemented here.
+///
+/// `decoderawtransaction` returns `txid`, `hash`, `version`, `size`, `vsize`,
+/// `weight`, `locktime`, `vin` and `vout`, and those nine are byte-identical to
+/// what verbose `getrawtransaction` returns for the same transaction. That
+/// matters: `vout[].scriptPubKey` carries `asm`, `desc`, `address` and `type`,
+/// which are Core's own script classification and address encoding. Producing
+/// them here would mean reproducing that classifier and getting it wrong at the
+/// edges. Asking Core cannot be wrong.
+///
+/// A one-element tuple rather than a newtype struct: serde renders a
+/// single-field tuple struct as the bare inner value, which JSON-RPC rejects
+/// with "Params must be an array or object".
+pub type DecodeRawTransactionParams = (String,);
+impl RpcMethod for DecodeRawTransaction {
+    type Params = DecodeRawTransactionParams;
+    type Response = Value;
+    fn as_str(&self) -> &'static str {
+        "decoderawtransaction"
+    }
+}
+impl Serialize for DecodeRawTransaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_str().serialize(serializer)
     }
 }
 
@@ -359,6 +426,33 @@ mod tests {
     /// The single-string `warnings` of Core 27 and earlier, and the `softforks`
     /// object dropped in 24.0.1, both still parse — nothing here names either.
     /// A proxy may be pointed at a node older than the one above.
+    /// Core reports -1 confirmations for a header that is not on the main
+    /// chain. This was `u32`, so a reorged-out block surfaced as "can't be
+    /// parsed as json" from whichever call happened to ask.
+    #[test]
+    fn parses_a_stale_block_header() {
+        let header: super::GetBlockHeaderResult = serde_json::from_str(
+            r#"{
+              "hash": "07bf0e81736da8923db558d5768a7006e2b93ce355103ca84af823fcade035e6",
+              "confirmations": -1,
+              "height": 804,
+              "version": 536870912,
+              "versionHex": "20000000",
+              "merkleroot": "578e22da1ca66f343029c9e95afa42e8ea34e1c407c57cb2f3e87f0073ae9362",
+              "time": 1787000000,
+              "mediantime": 1787000000,
+              "nonce": 1,
+              "bits": "207fffff",
+              "difficulty": 4.656542373906925e-10,
+              "chainwork": "0000000000000000000000000000000000000000000000000000000000000002",
+              "nTx": 2,
+              "previousblockhash": "60facf42231c33113d9bd67062d2ec290604458937db0fa0d0c13f2c074e9344"
+            }"#,
+        )
+        .expect("a stale header must parse");
+        assert_eq!(header.confirmations, -1);
+    }
+
     #[test]
     fn parses_older_node_shape() {
         let info: BlockchainInfo = serde_json::from_str(

--- a/src/users.rs
+++ b/src/users.rs
@@ -11,7 +11,10 @@ use crate::client::{
     PRUNE_ERROR_MESSAGE,
 };
 use crate::fetch_blocks::{fetch_block, fetch_block_raw};
-use crate::rpc_methods::{GetBlock, GetBlockHeader, GetBlockHeaderParams, GetBlockResult};
+use crate::rpc_methods::{
+    DecodeRawTransaction, GetBlock, GetBlockHeader, GetBlockHeaderParams, GetBlockResult,
+    GetRawTransaction,
+};
 use crate::state::State;
 
 pub use password::Password;
@@ -312,6 +315,11 @@ impl User {
                         _ => Ok(None), // TODO
                     }
                 }
+                GenericRpcParams::Array(params)
+                    if self.fetch_blocks && &*req.method == GetRawTransaction.as_str() =>
+                {
+                    self.intercept_raw_transaction(state, req, params).await
+                }
                 _ => Ok(None),
             }
         } else {
@@ -321,6 +329,220 @@ impl User {
                 status: Some(StatusCode::FORBIDDEN),
             })
         }
+    }
+
+    /// `getrawtransaction "txid" ( verbose "blockhash" )` for a block bitcoind
+    /// has pruned.
+    ///
+    /// **Only with a blockhash.** Core needs `txindex` to find a transaction
+    /// without one, and the proxy has no txid index to substitute; a request
+    /// that omits it is passed through so Core can answer or refuse on its own
+    /// terms. With a blockhash Core needs only the block, which is exactly what
+    /// this proxy can fetch from peers.
+    ///
+    /// This is what an Electrum server needs to serve a verbose transaction
+    /// lookup on a pruned node: electrs finds the blockhash in its own index and
+    /// passes it here.
+    async fn intercept_raw_transaction<'a>(
+        &self,
+        state: Arc<State>,
+        req: &'a RpcRequest<GenericRpcMethod>,
+        params: &'a [Value],
+    ) -> Result<Option<RpcResponse<GenericRpcMethod>>, RpcError> {
+        let (txid, verbose, blockhash) = match interceptable(params) {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+
+        let block = match fetch_block(state.clone(), blockhash).await {
+            Ok(Some(block)) => block,
+            Ok(None) => {
+                return Ok(Some(RpcResponse {
+                    id: req.id.clone(),
+                    result: None,
+                    error: Some(RpcError {
+                        code: MISC_ERROR_CODE,
+                        message: PRUNE_ERROR_MESSAGE.to_owned(),
+                        status: None,
+                    }),
+                }))
+            }
+            Err(e) => return Ok(Some(e.into())),
+        };
+
+        let tx = match block.txdata.iter().find(|tx| tx.txid() == txid) {
+            Some(tx) => tx,
+            // Core's own wording for this case, so a caller cannot tell the
+            // difference between a proxied answer and a direct one.
+            None => {
+                return Ok(Some(RpcResponse {
+                    id: req.id.clone(),
+                    result: None,
+                    error: Some(RpcError {
+                        code: MISC_ERROR_CODE,
+                        message: "No such transaction found in the provided block.".to_owned(),
+                        status: None,
+                    }),
+                }))
+            }
+        };
+        let hex = bitcoin::consensus::encode::serialize_hex(tx);
+
+        if !verbose {
+            return Ok(Some(RpcResponse {
+                id: req.id.clone(),
+                result: Some(Value::String(hex)),
+                error: None,
+            }));
+        }
+
+        // The nine fields decoderawtransaction returns are byte-identical to
+        // verbose getrawtransaction's, script classification and addresses
+        // included, so Core renders them rather than this reproducing them. The
+        // six that remain come from the header, which Core keeps when pruned.
+        let decode_req = RpcRequest {
+            id: None,
+            method: DecodeRawTransaction,
+            params: (hex.clone(),),
+        };
+        let header_req = RpcRequest {
+            id: None,
+            method: GetBlockHeader,
+            params: GetBlockHeaderParams(blockhash, Some(true)),
+        };
+        match futures::try_join!(
+            async { state.rpc_client.call(&decode_req).await?.into_result() },
+            async { state.rpc_client.call(&header_req).await?.into_result() },
+        ) {
+            Ok((mut decoded, header)) => {
+                let header = match header.into_right() {
+                    Some(h) => h,
+                    None => {
+                        return Ok(Some(
+                            RpcError::from(Error::msg("unexpected response for getblockheader"))
+                                .into(),
+                        ))
+                    }
+                };
+                // Core reports -1 confirmations for a header that is not on the
+                // main chain, and for a transaction in such a block it answers
+                // `in_active_chain: false` with `confirmations: 0` rather than a
+                // negative count. Match that, rather than asserting the block is
+                // current: a caller handed a reorged-out blockhash deserves the
+                // same answer here as it would get from bitcoind directly.
+                let in_active_chain = header.confirmations >= 0;
+                if let Some(obj) = decoded.as_object_mut() {
+                    obj.insert("in_active_chain".to_owned(), Value::Bool(in_active_chain));
+                    obj.insert("hex".to_owned(), Value::String(hex));
+                    obj.insert("blockhash".to_owned(), serde_json::json!(blockhash));
+                    obj.insert(
+                        "confirmations".to_owned(),
+                        serde_json::json!(if in_active_chain {
+                            header.confirmations
+                        } else {
+                            0
+                        }),
+                    );
+                    obj.insert("time".to_owned(), serde_json::json!(header.time));
+                    obj.insert("blocktime".to_owned(), serde_json::json!(header.time));
+                }
+                Ok(Some(RpcResponse {
+                    id: req.id.clone(),
+                    result: Some(decoded),
+                    error: None,
+                }))
+            }
+            Err(e) => Ok(Some(e.into())),
+        }
+    }
+}
+
+/// Whether a `getrawtransaction` call is one this proxy can answer, and its
+/// arguments if so.
+///
+/// `None` means pass it through to Core untouched, which is the right answer
+/// for everything the proxy cannot improve on:
+///
+/// - **no blockhash**: Core needs `txindex` to find the transaction, and the
+///   proxy has no txid index to substitute for one
+/// - **verbosity 2**: wants prevout data, which needs the undo files a pruned
+///   node has also discarded
+/// - **anything malformed**: Core writes better argument errors than this would
+fn interceptable(params: &[Value]) -> Option<(bitcoin::Txid, bool, bitcoin::BlockHash)> {
+    let blockhash = serde_json::from_value(params.get(2)?.clone()).ok()?;
+    let verbose = match params.get(1) {
+        None | Some(Value::Null) => false,
+        Some(Value::Bool(b)) => *b,
+        // Core accepts 0 and 1 for the boolean, and 2 for a form this cannot serve.
+        Some(Value::Number(n)) if n.as_u64() == Some(0) => false,
+        Some(Value::Number(n)) if n.as_u64() == Some(1) => true,
+        _ => return None,
+    };
+    let txid = serde_json::from_value(params.first()?.clone()).ok()?;
+    Some((txid, verbose, blockhash))
+}
+
+#[cfg(test)]
+mod raw_transaction_tests {
+    use super::interceptable;
+    use serde_json::json;
+
+    const TXID: &str = "780124042ee6e11fc3eeceec7d3b27379d71c4901e18d516ed1491eba025ba85";
+    const HASH: &str = "60facf42231c33113d9bd67062d2ec290604458937db0fa0d0c13f2c074e9344";
+
+    /// The form electrs sends, which is the whole reason this exists.
+    #[test]
+    fn verbose_with_a_blockhash_is_intercepted() {
+        let (txid, verbose, blockhash) =
+            interceptable(&[json!(TXID), json!(true), json!(HASH)]).expect("should intercept");
+        assert_eq!(txid.to_string(), TXID);
+        assert_eq!(blockhash.to_string(), HASH);
+        assert!(verbose);
+    }
+
+    #[test]
+    fn non_verbose_with_a_blockhash_is_intercepted() {
+        let (_, verbose, _) =
+            interceptable(&[json!(TXID), json!(false), json!(HASH)]).expect("should intercept");
+        assert!(!verbose);
+    }
+
+    /// Core takes 0 and 1 as well as false and true.
+    #[test]
+    fn numeric_verbosity_zero_and_one_are_intercepted() {
+        assert!(
+            !interceptable(&[json!(TXID), json!(0), json!(HASH)])
+                .unwrap()
+                .1
+        );
+        assert!(
+            interceptable(&[json!(TXID), json!(1), json!(HASH)])
+                .unwrap()
+                .1
+        );
+    }
+
+    /// Without a blockhash there is nothing to fetch: Core needs txindex and the
+    /// proxy has no index of its own. Passing through lets Core say so.
+    #[test]
+    fn no_blockhash_passes_through() {
+        assert!(interceptable(&[json!(TXID), json!(true)]).is_none());
+        assert!(interceptable(&[json!(TXID)]).is_none());
+    }
+
+    /// Verbosity 2 asks for prevouts, which need undo data a pruned node has
+    /// also discarded. Answering it without them would be answering wrongly.
+    #[test]
+    fn verbosity_two_passes_through() {
+        assert!(interceptable(&[json!(TXID), json!(2), json!(HASH)]).is_none());
+    }
+
+    #[test]
+    fn malformed_arguments_pass_through() {
+        assert!(interceptable(&[json!(TXID), json!("yes"), json!(HASH)]).is_none());
+        assert!(interceptable(&[json!(TXID), json!(true), json!("not a hash")]).is_none());
+        assert!(interceptable(&[json!("not a txid"), json!(true), json!(HASH)]).is_none());
+        assert!(interceptable(&[]).is_none());
     }
 }
 

--- a/src/users.rs
+++ b/src/users.rs
@@ -424,12 +424,9 @@ impl User {
                         ))
                     }
                 };
-                // Core reports -1 confirmations for a header that is not on the
-                // main chain, and for a transaction in such a block it answers
-                // `in_active_chain: false` with `confirmations: 0` rather than a
-                // negative count. Match that, rather than asserting the block is
-                // current: a caller handed a reorged-out blockhash deserves the
-                // same answer here as it would get from bitcoind directly.
+                // For a block off the main chain Core answers
+                // `in_active_chain: false` with `confirmations: 0`, and omits
+                // `time` and `blocktime` entirely.
                 let in_active_chain = header.confirmations >= 0;
                 if let Some(obj) = decoded.as_object_mut() {
                     obj.insert("in_active_chain".to_owned(), Value::Bool(in_active_chain));
@@ -443,8 +440,10 @@ impl User {
                             0
                         }),
                     );
-                    obj.insert("time".to_owned(), serde_json::json!(header.time));
-                    obj.insert("blocktime".to_owned(), serde_json::json!(header.time));
+                    if in_active_chain {
+                        obj.insert("time".to_owned(), serde_json::json!(header.time));
+                        obj.insert("blocktime".to_owned(), serde_json::json!(header.time));
+                    }
                 }
                 Ok(Some(RpcResponse {
                     id: req.id.clone(),


### PR DESCRIPTION
Follow-up to #29 and #30. This one closes the last thing I know of that stops electrs working against a pruned node.

## What it does

`getrawtransaction "txid" ( verbose "blockhash" )` only needs the block when you give it a blockhash. It does not need `txindex`. Fetching a block from peers is what this proxy already does, so the three-argument form is now answered even when bitcoind has pruned it.

Without a blockhash the call passes through untouched. Core needs `txindex` to find a transaction on its own and the proxy has no txid index to stand in for one, so answering would mean turning a clear error into a confusing one. Verbosity 2 passes through for the same reason: it wants prevout data, which lives in the undo files a pruned node has also discarded.

## Who asks for it

electrs, serving `blockchain.transaction.get` with verbose set. It finds the blockhash in its own index and then calls `getrawtransaction txid true blockhash`, which is exactly the shape this handles. On a pruned node that has always failed, so the verbose form of that method has never worked behind this proxy.

## Core does the rendering

I started out planning to build the verbose object here, and that was the wrong instinct. It would have meant reproducing Core's script classifier and address encoding in Rust, which is a lot of surface to get subtly wrong.

`decoderawtransaction` returns nine fields, and they are byte for byte what verbose `getrawtransaction` returns for the same transaction:

```
getrawtransaction verbose+blockhash   15 fields
decoderawtransaction                   9 fields
shared keys: 9   differing: none
```

Those nine include `vout[].scriptPubKey` with its `asm`, `desc`, `address` and `type`. So the proxy fetches the block, pulls the transaction out, hands it to Core to decode, and adds the six block-dependent fields from `getblockheader`, which Core still has when pruned. Nothing is reimplemented.

## One fix that goes slightly wider

`GetBlockHeaderResult.confirmations` was `u32`. Core returns `-1` for a header that is not on the main chain, so a reorged-out block failed to deserialize and came back as `can't be parsed as json`, which is a poor way to learn about a reorg. It is now `i32`.

That was already reachable through the existing `getblock` verbosity 1 path, which asks for the same verbose header, so this is not only about the new code. With it signed, a transaction in a stale block gets `in_active_chain: false` and `confirmations: 0`, matching bitcoind, rather than my first version's unconditional claim that the block was current. I only found that by testing a reorg, which is worth mentioning because I would not have guessed it.

## Testing

Two-node regtest setup, archival A feeding pruned B, transaction from a block 151 below B's prune height.

| case | result |
|---|---|
| direct to pruned bitcoind | `Block not available` |
| through the proxy, hex | returns the transaction |
| through the proxy, verbose | byte for byte identical to the archival node, field for field |
| input carrying a witness | identical, `hex` and `weight` included, so the witness survives |
| transaction in a reorged-out block | `in_active_chain: false`, `confirmations: 0`, identical to archival |
| electrs `transaction.get` verbose | works on a pruned block, right address and confirmation count |

Pass-through paths: no blockhash reaches Core's `use -txindex` message, verbosity 2 reaches `Block not available`, and a txid that is not in the named block gets Core's own wording for that.

26 unit tests pass. The new ones cover the dispatch decision, since that is where the branching is and where a later change could quietly break something: verbose true and false, numeric 0 and 1, no blockhash, verbosity 2, four malformed argument shapes, and the stale header.

`cargo clippy --all-targets` reports nothing new in the touched files. `cargo fmt --check` shows no diff in them either, though note `build.rs`, `proxy.rs` and `util.rs` already differ on master, so a bare `cargo fmt` will touch those. I left them alone.

CI will not run on this, since the only workflow here triggers on `v*` tags.
