### PR TITLE
Keep peer-fetched blocks in a bounded cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Two options tune what a fetch costs:
 
 Only peers advertising `NETWORK` and `WITNESS` are asked, since a fetched block is served with its witness data and checked against the witness commitment in its own coinbase.
 
+A block fetched from a peer is kept in memory so the next request for it does not go back to the network. Only peer-fetched blocks are cached, since anything bitcoind still holds is cheap to ask for again. `block_cache_size_mib` bounds it, 64 by default, and 0 turns it off. The bound matters: an unbounded cache would give back the disk saving that motivates running pruned in the first place.
+
 Peers are reached over clearnet, or through `tor_proxy` for `.onion` addresses. Reaching `.b32.i2p` peers additionally needs `i2p_proxy` pointed at an I2P SOCKSv5 proxy (i2pd's `socksproxy`, for instance); without one those peers cannot be used, as Tor cannot resolve them.
 
 Which network the peers speak is not configured. The p2p magic bytes and the default peer port are taken from bitcoind's own `getblockchaininfo` the first time a block has to be fetched, and cached for the life of the process — a node cannot change chain without a restart, and the proxy restarts with it. `main`, `test`, `testnet4`, `signet` and `regtest` are all understood, and a signet's magic is computed from the challenge that node reports, so custom signets work too.

--- a/btc_rpc_proxy.toml
+++ b/btc_rpc_proxy.toml
@@ -1,6 +1,8 @@
 bitcoind_user = "bitcoinrpc"
 bitcoind_password = "taxation is theft"
 bind_address = "127.0.0.1"
+# Mebibytes of peer-fetched blocks to keep in memory. 0 disables the cache.
+# block_cache_size_mib = 64
 
 [user.public]
 password = "public"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -79,6 +79,12 @@ argument = false
 doc = "Map of user names to user configs. Each user must specify `password` field and an array of allowed calls named `allowed_calls`"
 
 [[param]]
+name = "block_cache_size_mib"
+type = "usize"
+default = "64"
+doc = "How many mebibytes of peer-fetched blocks to keep in memory. Only blocks bitcoind no longer has are cached, since anything it still holds is cheap to ask for. Zero disables the cache."
+
+[[param]]
 name = "peer_timeout"
 type = "u64"
 default = "30"

--- a/src/block_cache.rs
+++ b/src/block_cache.rs
@@ -96,7 +96,7 @@ impl BlockCache {
         }
     }
 
-    /// Blocks held and bytes held, for tests and for logging.
+    /// Blocks held and bytes held.
     pub fn stats(&self) -> (usize, usize) {
         let inner = self.lock();
         (inner.blocks.len(), inner.bytes)

--- a/src/block_cache.rs
+++ b/src/block_cache.rs
@@ -1,0 +1,268 @@
+//! A bounded in-memory cache of blocks fetched from peers.
+//!
+//! Only blocks that came from the network are stored. A block bitcoind still
+//! has is already cheap to ask for, and caching it here would duplicate storage
+//! the node is paying for anyway.
+//!
+//! Caching a block is safe in a way that caching most things is not: the key is
+//! the block's own hash, and the fetch path has already checked that the bytes
+//! hash to it, that the merkle root matches, and that the witness commitment is
+//! satisfied. A block's contents cannot change, and a reorg does not make a
+//! block something else, so there is no staleness to reason about. The only
+//! thing bounded here is memory.
+//!
+//! Hand-rolled rather than pulling in an LRU crate, because it is fifty lines
+//! and the alternative is a dependency for one data structure.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+use bitcoin::hash_types::BlockHash;
+use hyper::body::Bytes;
+
+#[derive(Debug, Default)]
+struct Inner {
+    blocks: HashMap<BlockHash, Bytes>,
+    /// Least recently used at the front, which is the end eviction takes from.
+    order: VecDeque<BlockHash>,
+    bytes: usize,
+}
+
+#[derive(Debug)]
+pub struct BlockCache {
+    max_bytes: usize,
+    inner: Mutex<Inner>,
+}
+
+impl BlockCache {
+    /// A cache holding at most `max_bytes` of blocks. Zero disables it.
+    pub fn new(max_bytes: usize) -> Self {
+        BlockCache {
+            max_bytes,
+            inner: Mutex::new(Inner::default()),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.max_bytes > 0
+    }
+
+    /// A poisoned lock means some other thread panicked mid-update. The
+    /// invariants here are a map, a queue and a running total, so recovering is
+    /// preferable to propagating a panic into every later block fetch.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    pub fn get(&self, hash: &BlockHash) -> Option<Bytes> {
+        if !self.enabled() {
+            return None;
+        }
+        let mut inner = self.lock();
+        let block = inner.blocks.get(hash).cloned()?;
+        if let Some(pos) = inner.order.iter().position(|h| h == hash) {
+            inner.order.remove(pos);
+            inner.order.push_back(*hash);
+        }
+        Some(block)
+    }
+
+    pub fn insert(&self, hash: BlockHash, block: Bytes) {
+        if !self.enabled() {
+            return;
+        }
+        let size = block.len();
+        // A block bigger than the whole cache would evict everything else to
+        // hold one entry, which is worse than not caching it.
+        if size > self.max_bytes {
+            return;
+        }
+        let mut inner = self.lock();
+        if inner.blocks.contains_key(&hash) {
+            return;
+        }
+        inner.bytes += size;
+        inner.blocks.insert(hash, block);
+        inner.order.push_back(hash);
+        while inner.bytes > self.max_bytes {
+            match inner.order.pop_front() {
+                Some(evicted) => {
+                    if let Some(block) = inner.blocks.remove(&evicted) {
+                        inner.bytes -= block.len();
+                    }
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Blocks held and bytes held, for tests and for logging.
+    pub fn stats(&self) -> (usize, usize) {
+        let inner = self.lock();
+        (inner.blocks.len(), inner.bytes)
+    }
+
+    /// The running byte total agrees with what is actually held, and the queue
+    /// holds exactly the keys the map does. Test-only: the accounting is what
+    /// keeps the bound honest, and a drift in it would show up as memory growth
+    /// long before it showed up as a wrong answer.
+    #[cfg(test)]
+    fn check_invariants(&self) {
+        let inner = self.lock();
+        let summed: usize = inner.blocks.values().map(|b| b.len()).sum();
+        assert_eq!(inner.bytes, summed, "byte total drifted from what is held");
+        assert_eq!(
+            inner.order.len(),
+            inner.blocks.len(),
+            "queue and map disagree on how many blocks there are"
+        );
+        for hash in &inner.order {
+            assert!(
+                inner.blocks.contains_key(hash),
+                "queue holds a key the map does not"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BlockCache;
+    use bitcoin::hash_types::BlockHash;
+    use bitcoin::hashes::Hash;
+    use hyper::body::Bytes;
+
+    fn hash(n: u8) -> BlockHash {
+        let mut bytes = [0u8; 32];
+        bytes[0] = n;
+        BlockHash::from_slice(&bytes).unwrap()
+    }
+
+    fn block(size: usize) -> Bytes {
+        Bytes::from(vec![0u8; size])
+    }
+
+    #[test]
+    fn a_stored_block_comes_back() {
+        let cache = BlockCache::new(1024);
+        cache.insert(hash(1), block(100));
+        assert_eq!(cache.get(&hash(1)).map(|b| b.len()), Some(100));
+        assert_eq!(cache.get(&hash(2)), None);
+    }
+
+    /// The bound is the point: memory is what stops this eating the disk saving
+    /// that motivates running pruned in the first place.
+    #[test]
+    fn eviction_keeps_the_cache_under_its_bound() {
+        let cache = BlockCache::new(250);
+        for n in 1..=5 {
+            cache.insert(hash(n), block(100));
+        }
+        let (count, bytes) = cache.stats();
+        assert!(bytes <= 250, "held {} bytes, bound was 250", bytes);
+        assert_eq!(count, 2, "two 100-byte blocks fit under 250");
+        assert!(cache.get(&hash(1)).is_none(), "the oldest should be gone");
+        assert!(cache.get(&hash(5)).is_some(), "the newest should be held");
+    }
+
+    /// Least *recently used*, not least recently inserted: reading a block
+    /// should save it from the next eviction.
+    #[test]
+    fn a_read_block_survives_longer_than_an_unread_one() {
+        let cache = BlockCache::new(250);
+        cache.insert(hash(1), block(100));
+        cache.insert(hash(2), block(100));
+        assert!(cache.get(&hash(1)).is_some());
+        cache.insert(hash(3), block(100));
+        assert!(
+            cache.get(&hash(1)).is_some(),
+            "read recently, should survive"
+        );
+        assert!(cache.get(&hash(2)).is_none(), "not read, should be evicted");
+    }
+
+    #[test]
+    fn a_block_larger_than_the_cache_is_not_stored() {
+        let cache = BlockCache::new(100);
+        cache.insert(hash(1), block(50));
+        cache.insert(hash(2), block(500));
+        assert!(cache.get(&hash(2)).is_none(), "oversized, not stored");
+        assert!(cache.get(&hash(1)).is_some(), "and it evicted nothing");
+    }
+
+    #[test]
+    fn zero_disables_it() {
+        let cache = BlockCache::new(0);
+        assert!(!cache.enabled());
+        cache.insert(hash(1), block(100));
+        assert!(cache.get(&hash(1)).is_none());
+        assert_eq!(cache.stats(), (0, 0));
+    }
+
+    #[test]
+    fn inserting_the_same_block_twice_counts_it_once() {
+        let cache = BlockCache::new(1024);
+        cache.insert(hash(1), block(100));
+        cache.insert(hash(1), block(100));
+        assert_eq!(cache.stats(), (1, 100));
+        cache.check_invariants();
+    }
+
+    /// Mixed inserts, repeats and reads against a cache small enough to be
+    /// evicting throughout, checking the accounting after every step. The bound
+    /// is only as good as the running total that enforces it.
+    #[test]
+    fn the_accounting_holds_through_churn() {
+        let cache = BlockCache::new(1000);
+        for round in 0..40u8 {
+            cache.insert(hash(round), block(60 + (round as usize % 7) * 30));
+            cache.insert(hash(round / 2), block(100));
+            let _ = cache.get(&hash(round / 3));
+            cache.check_invariants();
+            let (_, bytes) = cache.stats();
+            assert!(bytes <= 1000, "round {}: held {} bytes", round, bytes);
+        }
+    }
+
+    /// Blocks vary from a few hundred bytes to megabytes, and the bound has to
+    /// hold across that range rather than for uniform test-sized entries.
+    #[test]
+    fn the_bound_holds_for_realistic_block_sizes() {
+        let cache = BlockCache::new(8 * 1024 * 1024);
+        for n in 0..40u8 {
+            // roughly 200 bytes to 4 MiB, the real spread
+            let size = if n % 5 == 0 {
+                200
+            } else {
+                (n as usize % 4 + 1) * 1024 * 1024
+            };
+            cache.insert(hash(n), block(size));
+            cache.check_invariants();
+            assert!(cache.stats().1 <= 8 * 1024 * 1024);
+        }
+    }
+
+    /// The lock is what makes this safe to share; the accounting is what makes
+    /// it correct. Hammer both at once.
+    #[test]
+    fn concurrent_use_keeps_the_accounting_straight() {
+        use std::sync::Arc;
+        let cache = Arc::new(BlockCache::new(4096));
+        let threads: Vec<_> = (0..8u8)
+            .map(|t| {
+                let cache = Arc::clone(&cache);
+                std::thread::spawn(move || {
+                    for n in 0..64u8 {
+                        cache.insert(hash(t.wrapping_mul(64).wrapping_add(n)), block(200));
+                        let _ = cache.get(&hash(n));
+                    }
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().expect("a worker panicked");
+        }
+        cache.check_invariants();
+        assert!(cache.stats().1 <= 4096);
+    }
+}

--- a/src/create_state.rs
+++ b/src/create_state.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::Error;
 use btc_rpc_proxy::users::Password;
-use btc_rpc_proxy::{AuthSource, Peers, RpcClient, State, TorState};
+use btc_rpc_proxy::{AuthSource, BlockCache, Peers, RpcClient, State, TorState};
 use slog::Drain;
 use systemd_socket::SocketAddr;
 use tokio::sync::{OnceCell, RwLock};
@@ -138,6 +138,11 @@ pub fn create_state() -> Result<(State, SocketAddr), Error> {
             max_peer_age: Duration::from_secs(config.max_peer_age),
             max_peer_concurrency: config.max_peer_concurrency,
             network: OnceCell::new(),
+            // Saturating, because a nonsense value here would otherwise wrap:
+            // in release that silently yields a tiny cache, and in debug it
+            // panics at startup. Saturating gives "as much as this machine
+            // could address", which is the honest reading of an absurd number.
+            block_cache: BlockCache::new(config.block_cache_size_mib.saturating_mul(1024 * 1024)),
         },
         bind_addr,
     ))

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -430,6 +430,12 @@ pub async fn fetch_block_raw(
     state: Arc<State>,
     hash: BlockHash,
 ) -> Result<Option<Bytes>, RpcError> {
+    // Ahead of bitcoind, not behind it: the cache only holds blocks bitcoind did
+    // not have, so a hit is always cheaper than the round trip that would miss.
+    if let Some(block) = state.block_cache.get(&hash) {
+        debug!(state.logger, "Serving a block from the peer-fetch cache."; "block_hash" => %hash);
+        return Ok(Some(block));
+    }
     if let Some(block) = fetch_block_from_self(&*state, hash).await? {
         return Ok(Some(block));
     }
@@ -452,7 +458,9 @@ pub async fn fetch_block_raw(
     block
         .consensus_encode(&mut serialized)
         .map_err(Error::from)?;
-    Ok(Some(Bytes::from(serialized)))
+    let serialized = Bytes::from(serialized);
+    state.block_cache.insert(hash, serialized.clone());
+    Ok(Some(serialized))
 }
 
 pub async fn fetch_block(state: Arc<State>, hash: BlockHash) -> Result<Option<Block>, RpcError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate slog;
 
+pub mod block_cache;
 pub mod client;
 pub mod fetch_blocks;
 pub mod proxy;
@@ -19,6 +20,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
 };
 
+pub use crate::block_cache::BlockCache;
 pub use crate::client::{AuthSource, RpcClient};
 pub use crate::fetch_blocks::Peers;
 use crate::proxy::proxy_request;

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,6 +8,7 @@ use bitcoin::hashes::{sha256d, Hash};
 use slog::Logger;
 use tokio::sync::{OnceCell, RwLock};
 
+use crate::block_cache::BlockCache;
 use crate::client::{RpcClient, RpcRequest};
 use crate::fetch_blocks::{PeerHandle, Peers};
 use crate::rpc_methods::{BlockchainInfo, GetBlockchainInfo};
@@ -103,6 +104,8 @@ pub struct State {
     /// Filled in from bitcoind the first time a block is fetched from a peer.
     /// A node cannot change chain without a restart, and this restarts with it.
     pub network: OnceCell<NetworkParams>,
+    /// Blocks fetched from peers, so the same one is not pulled twice.
+    pub block_cache: BlockCache,
 }
 impl State {
     pub fn leak(self) -> &'static Self {


### PR DESCRIPTION
Every request for a block bitcoind no longer has goes out to the P2P network, even if the proxy fetched that exact block a second earlier. Nothing remembers it.

That costs more than it sounds like, because one caller can ask twice inside a single request. An Electrum server resolving a verbose transaction fetches the block to find the transaction, then asks for the transaction itself, and both legs land on the same block.

I measured it on a two-node regtest setup with a pruned node. An explorer block page showing ten transactions triggered twenty peer fetches for ten inputs: two per input, every time, and twenty again on a second view of the same page.

With the cache, that same page:

```
                     peer fetches   cache hits
cold, empty cache          9             9
warm, same page            0            18
```

Loopback hides what that is worth. On the mainnet measurements I took for this, a peer fetch runs about 162 ms median on clearnet and 2118 ms over Tor, and is essentially flat in block size, so it is round-trip cost rather than transfer cost. For a page touching fifty blocks over Tor, halving the count is the difference between a page that loads and one that times out.

A few notes on the shape of it.

Only peer-fetched blocks are stored. A block bitcoind still holds is cheap to ask for, and caching it here would duplicate storage the node is already paying for. The lookup sits ahead of the bitcoind call rather than behind it, since the cache only ever holds blocks bitcoind did not have, so a hit is always cheaper than the round trip it replaces.

Caching a block is safer than caching most things. The key is the block's own hash, and by the time a block reaches the cache the fetch path has already checked that the bytes hash to it, that the merkle root matches, and that the witness commitment is satisfied. Block contents cannot change, and a reorg does not make a block something else, so there is no staleness to reason about. Memory is the only thing left to bound.

New config parameter `block_cache_size_mib`, 64 by default, 0 to disable. The bound is the point: an unbounded cache hands back the disk saving that motivates running pruned in the first place. 64 MiB holds sixteen mainnet blocks even at maximum size and rather more at typical ones, which covers the repeat-within-a-request case and a page of history without being a number anyone has to think about.

Hand-rolled instead of adding an LRU dependency, since it comes out to a map, a queue and a running total.

Nine tests cover retrieval, eviction staying under the bound, least-recently-used ordering rather than insertion order, a block larger than the whole cache being refused rather than evicting everything to hold it, zero disabling it, and a repeated insert counting once. Three of them check the byte accounting directly, since that running total is what makes the bound mean anything: under churn, across sizes from a few hundred bytes to four mebibytes, and from eight threads at once. I confirmed those bite by deliberately dropping the subtraction in the eviction path, which fails four tests.

Also verified end to end on the regtest setup: three requests for a pruned block produce one peer fetch and two cache hits, and with `block_cache_size_mib = 0`, three fetches and no hits.

This one is independent of #31 and sits directly on master, so either can merge first.
